### PR TITLE
Working minikube audit events

### DIFF
--- a/dev/minikube/.gitignore
+++ b/dev/minikube/.gitignore
@@ -1,0 +1,1 @@
+audit.log

--- a/dev/minikube/apiserver-config-v2.patch.sh
+++ b/dev/minikube/apiserver-config-v2.patch.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+
+IFS=''
+
+FILENAME="/etc/kubernetes/manifests/kube-apiserver.yaml"
+
+TMPFILE="/tmp/kube-apiserver.yaml.patched"
+rm -f "$TMPFILE"
+
+while read LINE
+do
+    echo "$LINE" >> "$TMPFILE"
+    case "$LINE" in
+        *"- kube-apiserver"*)
+            echo "    - --audit-log-path=/tmp/files/audit.log" >> "$TMPFILE"
+            echo "    - --audit-policy-file=/tmp/files/audit-policy.yaml" >> "$TMPFILE"
+            echo "    - --audit-webhook-config-file=/tmp/files/webhook-config.yaml" >> "$TMPFILE"
+            ;;
+        *"volumeMounts:"*)
+            echo "    - mountPath: /tmp/files/" >> "$TMPFILE"
+            echo "      name: data" >> "$TMPFILE"
+            ;;
+        *"volumes:"*)
+            echo "  - hostPath:" >> "$TMPFILE"
+            echo "      path: /tmp/files" >> "$TMPFILE"
+            echo "    name: data" >> "$TMPFILE"
+            ;;
+
+    esac
+done < "$FILENAME"
+
+cp "$FILENAME" "/tmp/kube-apiserver.yaml.original"
+cp "$TMPFILE" "$FILENAME"

--- a/dev/minikube/start-minikube-audit.sh
+++ b/dev/minikube/start-minikube-audit.sh
@@ -2,11 +2,12 @@
 set -e
 set -x
 minikube start --v=4  --mount --mount-string=$PWD:/tmp/files \
-         --feature-gates=AdvancedAuditing=true \
-         --extra-config=apiserver.audit-log-path=/tmp/files/audit.log
-         #2>&1 | tee /tmp/minikube.log
-#sleep 15
+         --feature-gates=AdvancedAuditing=true
+echo
 echo "Running this should update kube-apiserver.yaml and trigger a restart:"
 echo ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no \
     -i $(minikube ssh-key) docker@$(minikube ip) \
-    sudo /tmp/files/apiserver-config.patch.sh
+    sudo /tmp/files/apiserver-config-v2.patch.sh
+echo
+echo "Running this sets up a test server to receive events from the webhook:"
+echo "go run test-server.go"

--- a/dev/minikube/test-server.go
+++ b/dev/minikube/test-server.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httputil"
+	"log"
+)
+
+func hello(w http.ResponseWriter, r *http.Request) {
+	fmt.Fprintf(w, "hello world")
+}
+
+func log_events(w http.ResponseWriter, r *http.Request) {
+	requestDump, err := httputil.DumpRequest(r, true)
+	if err != nil {
+		fmt.Println(err)
+	}
+	fmt.Println(string(requestDump))
+}
+
+func main() {
+	http.HandleFunc("/", hello)
+	http.HandleFunc("/events", log_events)
+	err := http.ListenAndServe(":9900", nil)
+	if err != nil {
+		log.Fatal("ListenAndServe: ", err)
+	}
+}

--- a/dev/minikube/webhook-config.yaml
+++ b/dev/minikube/webhook-config.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Config
 clusters:
 - cluster:
-    server: http://<PRIMARY_NETWORK_INTERFACE_IP>:8080/events
+    server: http://192.168.99.1:9900/events
   name: hit-config
 contexts:
 - context:


### PR DESCRIPTION
Changed the config patch to a basic shell script that injects volume yaml and command line arguments. This is necessary because the order of the lines in the config is not always the same.

Also created a basic webserver in go to provide an audit webhook for testing and dump events to console.