### PR TITLE
Tighten up API coverage

### DIFF
--- a/dev/audit-log-review/README.md
+++ b/dev/audit-log-review/README.md
@@ -12,7 +12,8 @@ pip install -r requirements.txt
 
 To load the audit log into the database
 ```
-python logreview.py load-audit <audit log path> <app name>
+python logreview.py load-audit <audit log path> <kubernetes version or branch> <app name>
+# eg: python logreview.py load-audit kube-apiserver-audit.log release-1.12 e2e
 ```
 
 Now that the log is in the database, lets start the webserver and have a look

--- a/dev/audit-log-review/lib/parsers.py
+++ b/dev/audit-log-review/lib/parsers.py
@@ -27,6 +27,8 @@ def load_swagger_file(url, cache=False):
             else:
                 # Fall back to old way of doing things
                 key = hashlib.md5(url).hexdigest()
+            if not os.path.exists('cache'):
+                os.mkdir('cache')
             cache_path = os.path.join('cache', "swagger_%s.json" % key)
             if not os.path.exists(cache_path):
                 swagger = requests.get(url).json()
@@ -80,10 +82,18 @@ def load_openapi_spec(url):
         path_data['level'] = parse_level_from_path(path)
         # methods
         path_data['methods'] = {}
-        methods = swagger['paths'][path].keys()
-        for method in methods:
+        for method, swagger_method in swagger['paths'][path].items():
             if method == "parameters":
                 continue
+            if 'deprecated' in swagger_method.get('description', '').lower():
+                print("Skipping DEPRECATED method")
+                continue
+            produces = swagger_method.get('produces', [])
+            can_watch = ('application/json;stream=watch' in produces or
+                         'application/vnd.kubernetes.protobuf;stream=watch' in produces)
+            must_watch = swagger_method.get('x-kubernetes-action') == 'watch'
+            if must_watch:
+                print("must watch " + path)
             method_data = {}
             tags = sorted(swagger['paths'][path][method].get('tags', list()))
             if len(tags) > 0:
@@ -95,7 +105,10 @@ def load_openapi_spec(url):
             else:
                 method_data['category'] = ''
             # todo - request + response
-            path_data['methods'][method] = method_data
+            if not must_watch:
+                path_data['methods'][method] = method_data
+            if can_watch:
+                path_data['methods']['watch'] = method_data
         # use the path regex as the key so that we search for a match easily
         openapi_spec['paths'][path_regex] = path_data
 
@@ -119,10 +132,11 @@ def load_audit_log(path):
             raw_event = json.loads(entry)
             # change verb to represent http request
             verb_tt = {
-                'get': ['get', 'list', 'watch', 'proxy'],
+                'get': ['get', 'list', 'proxy'],
                 'put': ['update', 'patch'],
                 'post': ['create'],
-                'delete': ['delete', 'deletecollection']
+                'delete': ['delete', 'deletecollection'],
+                'watch': ['watch', 'watchlist'],
             }
 
             for method, verbs in verb_tt.items():

--- a/dev/audit-log-review/logreview.py
+++ b/dev/audit-log-review/logreview.py
@@ -160,8 +160,8 @@ def usage_and_exit():
     print "    - Show this message."
     print "  logreview.py load-coverage <filename>"
     print "    - Load Google Docs test coverage spreadsheet from CSV."
-    print "  logreview.py load-audit <filename> <appname>"
-    print "    - Load Kubernetes audit log for app into database."
+    print "  logreview.py load-audit <filename> <branch_or_tag> <appname>"
+    print "    - Load Kubernetes audit log using openapi spec from specified branch or tag for app into database."
     print "  logreview.py remove-audit <appname>"
     print "    - Delete Kubernetes audit log for app from database."
     print "  logreview.py export-data <exporter-name> <output-filename> <appname (optional)>"
@@ -197,14 +197,16 @@ def main():
         Endpoint.update_from_coverage(rows)
         return # we are done
     elif sys.argv[1] == 'load-audit':
-        if len(sys.argv) < 4:
+        if len(sys.argv) < 5:
             usage_and_exit()
         filename = sys.argv[2]
         if not os.path.isfile(filename):
             print "Invalid filename given"
             usage_and_exit()
-        appname = sys.argv[3]
-        openapi_spec = load_openapi_spec(OPENAPI_SPEC_URL)
+        branch_or_tag = sys.argv[3]
+        openapi_uri = "https://raw.githubusercontent.com/kubernetes/kubernetes/%s/api/openapi-spec/swagger.json" % (branch_or_tag)
+        appname = sys.argv[4]
+        openapi_spec = load_openapi_spec(openapi_uri)
         audit_log = load_audit_log(filename)
         report = generate_coverage_report(openapi_spec, audit_log)
         App.update_from_results(appname, report['results'])

--- a/dev/e2e-coverage-view/README.md
+++ b/dev/e2e-coverage-view/README.md
@@ -12,7 +12,7 @@ pip install -r requirements.txt
 
 To load the audit log into the database
 ```
-python import.py <audit log path>
+python import.py <audit log path> <kubernetes tag or branch>
 ```
 
 Now that the log is in the database, lets start the webserver and have a look

--- a/dev/e2e-coverage-view/import.py
+++ b/dev/e2e-coverage-view/import.py
@@ -5,13 +5,12 @@ from lib.parsers import *
 
 
 # this is a bit silly given we have it locally but we'll run with it for now.
-OPENAPI_SPEC_URL = "https://raw.githubusercontent.com/kubernetes/kubernetes/master/api/openapi-spec/swagger.json"
 
 
 @db_session
-def do_import(path):
+def do_import(path, openapi_spec):
     log = load_audit_log(path)
-    spec = load_openapi_spec(OPENAPI_SPEC_URL)
+    spec = load_openapi_spec(openapi_spec)
     endpoints = {}
 
     # we need to have an entry for everything in the spec, including entries
@@ -47,7 +46,15 @@ def do_import(path):
             hits[t] = EndpointHit(endpoint=endpoints[path, method], user_agent=ua, count=1)
     commit()
 
+def usage_and_exit():
+    print "Usage:"
+    print "  import.py <audit_log_path> <branch_or_tag>"
+    exit(1)
 
 if __name__ == '__main__':
     import sys
-    do_import(sys.argv[1])
+    if len(sys.argv) < 3:
+        usage_and_exit()
+    branch_or_tag = sys.argv[2]
+    openapi_uri = "https://raw.githubusercontent.com/kubernetes/kubernetes/%s/api/openapi-spec/swagger.json" % (branch_or_tag)
+    do_import(sys.argv[1], openapi_uri)


### PR DESCRIPTION
- Use the openapi spec from the same branch of code that we're testing
- Filter out openapi endpoints that have the word deprecated in their
  description (ultimately we should be looking at the `deprecated`
  field once kubernetes adds this to their openapi spec (ref #35)