### PR TITLE
Improve api coverage related to proxy endpoints

### DIFF
--- a/dev/e2e-coverage-view/lib/parsers.py
+++ b/dev/e2e-coverage-view/lib/parsers.py
@@ -44,14 +44,23 @@ def load_swagger_file(url, cache=False):
     return swagger
 
 
+# k8s appears to allow/expect a trailing {path} variable to capture everything
+# remaining in the path, including '/' characters, which doesn't appear to be
+# allowed according to the openapi 2.0 or 3.0 specs
+# (ref: https://github.com/OAI/OpenAPI-Specification/issues/892)
+K8S_PATH_VARIABLE_PATTERN = re.compile("{(path)}$")
 VARIABLE_PATTERN = re.compile("{([^}]+)}")
 def compile_path_regex(path):
+    # first replace the special trailing {path} wildcard with a named regex
+    path_regex = K8S_PATH_VARIABLE_PATTERN.sub("(?P<\\1>.+)", path).rstrip('/')
     # replace wildcards in {varname} format to a named regex
-    path_regex = VARIABLE_PATTERN.sub("(?P<\\1>[^/]+)", path).rstrip('/')
-    if path_regex.endswith("proxy"): # allow for longer paths in proxy
-        path_regex += ".*$"
+    path_regex = VARIABLE_PATTERN.sub("(?P<\\1>[^/]+)", path_regex).rstrip('/')
+    # TODO(spiffxp): unsure if trailing / _should_ be counted toward /proxy
+    if path_regex.endswith("proxy"): # allow proxy to catch a trailing /
+        path_regex += "/?$"
     else:
         path_regex += "$"
+    print 'Converted path: %s into path_regex: %s' % (path, path_regex)
     return path_regex
 
 
@@ -88,7 +97,7 @@ def load_openapi_spec(url):
             if method == "parameters":
                 continue
             if 'deprecated' in swagger_method.get('description', '').lower():
-                print("Skipping DEPRECATED method")
+                print 'Skipping deprecated endpoint %s %s' % (method, path)
                 continue
             produces = swagger_method.get('produces', [])
             can_watch = ('application/json;stream=watch' in produces or
@@ -133,10 +142,12 @@ def load_audit_log(path):
     with open(path, "rb") as logfile:
         for entry in logfile:
             raw_event = json.loads(entry)
-            # change verb to represent http request
+            # TODO(spiffxp): the audit log verb is empty when we HEAD or OPTIONS some k8s endpoints
+            # translate the audit log 'verb' into a corresponding openapi 'method'
             verb_tt = {
                 'get': ['get', 'list', 'proxy'],
-                'put': ['update', 'patch'],
+                'patch': ['patch'],
+                'put': ['update'],
                 'post': ['create'],
                 'delete': ['delete', 'deletecollection'],
                 'watch': ['watch', 'watchlist'],
@@ -163,7 +174,6 @@ def find_openapi_entry(openapi_spec, event):
     # 2) Indexed by prefix patterns to cut down search time
     for prefix in prefix_cache:
         if prefix is not None and url.path.startswith(prefix):
-            # print prefix, url.path
             paths = prefix_cache[prefix]
             break
     else:


### PR DESCRIPTION
I started digging into coverage of some of kubernetes' proxy endpoints
(eg: pods/foo/proxy or pods/foo/proxy/some/nested/path) and found some
discrepancies.

- It turns out there are lots of openapi endpoints that have PATCH as
  their method, so we shouldn't normalize PATCH to PUT.
- The regex for foo/proxy was catching all traffic to foo/proxy/ and
  foo/proxy/some/nested/path, so I redid the regexes for proxy
- Redid logging a bit so I could see 'verb path' for things

Also, now that e2e.test is sending test names in its user agent, I
updated the e2e-coverage-view code to split that up. This allowed me to
query which endpoints a given proxy test was hitting, which is what led
me to digging into the rest of this