### PR TITLE
apisnoop.sh: Only download processed artifacts listed in sources.yaml

### DIFF
--- a/apisnoop.sh
+++ b/apisnoop.sh
@@ -63,7 +63,9 @@ upload_apiusage() {
 
 download_apiusage() {
   mkdir -p "$APISNOOP_DEST"
-  gsutil -m cp -R -n "$APISNOOP_GCS_PREFIX" "$APISNOOP_DEST"
+  cat "$APISNOOP_SOURCES" | \
+   yq -r '."sig-release"[] | to_entries[] | "\(.key)/\(.value[0])"' | \
+   while read bucket; do gsutil -m cp -R -n "${APISNOOP_GCS_PREFIX}"$bucket "$APISNOOP_DEST"; done
   mv "$APISNOOP_DEST"/*/* "$APISNOOP_DEST"
 }
 

--- a/apisnoop.sh
+++ b/apisnoop.sh
@@ -66,7 +66,7 @@ download_apiusage() {
   cat "$APISNOOP_SOURCES" | \
    yq -r '."sig-release"[] | to_entries[] | "\(.key)/\(.value[0])"' | \
    while read bucket; do gsutil -m cp -R -n "${APISNOOP_GCS_PREFIX}"$bucket "$APISNOOP_DEST"; done
-  mv "$APISNOOP_DEST"/*/* "$APISNOOP_DEST"
+  mv "$APISNOOP_DEST"/*/* "$APISNOOP_DEST" || true
 }
 
 if [ $# -eq 0 ]; then

--- a/data-gen/requirements.txt
+++ b/data-gen/requirements.txt
@@ -6,3 +6,4 @@ ipdb
 pyyaml
 click
 soupsieve
+yq

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "npm": ">= 3.0.0"
   },
   "scripts": {
-    "postinstall": "curl https://storage.googleapis.com/pub/gsutil.tar.gz | tar xfz - ; export PATH=$PWD/gsutil:$PATH ; echo $PATH ; ./apisnoop.sh --download-apiusage",
+    "postinstall": "curl https://storage.googleapis.com/pub/gsutil.tar.gz | tar xfz - ; export PATH=$PWD/gsutil:$PATH ; echo $PATH ; sleep 99999 ; ./apisnoop.sh --download-apiusage",
     "start": "nodemon src/"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "npm": ">= 3.0.0"
   },
   "scripts": {
-    "postinstall": "curl https://storage.googleapis.com/pub/gsutil.tar.gz | tar xfz - ; export PATH=$PWD/gsutil:$PATH ; echo $PATH ; apt-get update ; apt-get install -y jq python3-pip ; pip3 install yq ; ./apisnoop.sh --download-apiusage",
+    "postinstall": "curl https://storage.googleapis.com/pub/gsutil.tar.gz | tar xfz - ; export PATH=$PWD/gsutil:$PATH ; echo $PATH ; ./apisnoop.sh --download-apiusage",
     "start": "nodemon src/"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "npm": ">= 3.0.0"
   },
   "scripts": {
-    "postinstall": "curl https://storage.googleapis.com/pub/gsutil.tar.gz | tar xfz - ; export PATH=$PWD/gsutil:$PATH ; echo $PATH ; sleep 99999 ; ./apisnoop.sh --download-apiusage",
+    "postinstall": "curl https://storage.googleapis.com/pub/gsutil.tar.gz | tar xfz - ; curl https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 -o jq ; chmod +x jq ; curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py ;  python get-pip.py --user ; export PATH=$PWD/gsutil:$PWD/jq:/app/.local/bin:$PATH ; pip install --user yq ; ./apisnoop.sh --download-apiusage",
     "start": "nodemon src/"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "npm": ">= 3.0.0"
   },
   "scripts": {
-    "postinstall": "curl https://storage.googleapis.com/pub/gsutil.tar.gz | tar xfz - ; export PATH=$PWD/gsutil:$PATH ; echo $PATH ; ./apisnoop.sh --download-apiusage",
+    "postinstall": "curl https://storage.googleapis.com/pub/gsutil.tar.gz | tar xfz - ; export PATH=$PWD/gsutil:$PATH ; echo $PATH ; apt-get update ; apt-get install -y jq python3-pip ; pip3 install yq ; ./apisnoop.sh --download-apiusage",
     "start": "nodemon src/"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "npm": ">= 3.0.0"
   },
   "scripts": {
-    "postinstall": "curl https://storage.googleapis.com/pub/gsutil.tar.gz | tar xfz - ; curl https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 -o jq ; chmod +x jq ; curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py ;  python get-pip.py --user ; export PATH=$PWD/gsutil:$PWD/jq:/app/.local/bin:$PATH ; pip install --user yq ; ./apisnoop.sh --download-apiusage",
+    "postinstall": "curl https://storage.googleapis.com/pub/gsutil.tar.gz | tar xfz - ; wget -O jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64  ; chmod +x ./jq ; mkdir bin ; mv jq bin/ ; curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py ;  python get-pip.py --user ; export PATH=$PWD/gsutil:$PWD/bin:/app/.local/bin:$PATH ; pip install --user yq ; ./apisnoop.sh --download-apiusage",
     "start": "nodemon src/"
   },
   "dependencies": {


### PR DESCRIPTION
Resolves issue: https://github.com/cncf/apisnoop/issues/126

The `--download-apiusage` command was just downloading the entire bucket. This change will make it only download the prefixes listed in `sources.yaml`