### PR TITLE
Add useragent filter to Web app

### DIFF
--- a/backend.org
+++ b/backend.org
@@ -280,3 +280,19 @@ The core file in this processed folder is  =apisnoop.json=.  This lists all the 
      #+END_SRC
 
       This will read the file and send the data to our releases service, but releaes will reject it by default because some of the fiels in the data have periods and our database does not like that.  So we add a hook to Releases that takes this data given to it and changes it's peirods to underscores before trying to add it to the database.  We generated the hook using feathers/cli, setting it to be before any create or update action...meaning it manipualtes the file BEFORE it is added to the db through CREATE or UPDATE
+
+** Middleware
+   :PROPERTIES:
+   :header-args: :noweb yes :tangle ./src/middleware/index.js
+   :END:
+   This is where we can hold express middleware; express being the server framework that Feathers is atop of.
+   #+NAME: index.js
+   #+BEGIN_SRC js
+// eslint-disable-next-line no-unused-vars
+module.exports = function (app) {
+  // Add your custom middleware here. Remember that
+  // in Express, the order matters.
+};
+
+
+   #+END_SRC

--- a/client/client.org
+++ b/client/client.org
@@ -1751,9 +1751,9 @@ k*** Selector
           'selectQueryObject',
           (useragents, query) => {
             if (useragents == null || !query) return []
-            if (query.useragent && query.useragent.length) {
+            if (query.useragents && query.useragents.length) {
               return filter(useragents, (ua) => {
-                var inputAsRegex = new RegExp(query.useragent)
+                var inputAsRegex = new RegExp(query.useragents)
                 return inputAsRegex.test(ua.name)
               })
             } else {
@@ -2880,7 +2880,7 @@ The interior label was a bit tricky to do, and it has some logic put in that i d
         function handleSubmit (e) {
           e.preventDefault()
           doUpdateQuery({
-            useragent: e.target[0].value
+            useragents: e.target[0].value
           })
           doUpdateUseragentsInput('')
 

--- a/client/client.org
+++ b/client/client.org
@@ -2839,12 +2839,15 @@ The interior label was a bit tricky to do, and it has some logic put in that i d
       import { connect } from 'redux-bundler-react'
       import UseragentSearchBar from './useragent-search-bar'
       import UseragentSearchResults from './useragent-search-results'
+      import UseragentsActiveFilter from './useragents-active-filter'
+
 
       function UseragentSearchContainer (props) {
         return (
           <div id='useragent-search'>
             <UseragentSearchBar />
             <UseragentSearchResults />
+            <UseragentsActiveFilter />
           </div>
         )
       }
@@ -2909,15 +2912,44 @@ The interior label was a bit tricky to do, and it has some logic put in that i d
         const useragents = props.useragentsFilteredByInput
         if(useragents == null || useragents.length <= 0) return null
         return (
-            <ul>
-              {useragents.map(useragent => <li>{ useragent }</li>)}
+          <div id='useragent-search-results' className='mt2 mb0'>
+            <strong className='f5'>Useragents covered by this regex</strong>
+            <ul className="list ph0">
+              {useragents.map(useragent => <li key={useragent} className="f6 dib mr2 pa2 mid-gray">{ useragent }</li>)}
             </ul>
+          </div>
         )
       }
 
       export default connect(
         'selectUseragentsFilteredByInput',
         UseragentSearchResults
+      )
+    #+END_SRC
+*** Useragents Filter Selection
+    :PROPERTIES:
+    :header-args: :tangle ./src/components/useragents-active-filter.js
+    :END:
+    #+BEGIN_SRC js
+      import React from 'react'
+      import {connect} from 'redux-bundler-react'
+
+      function UseragentsActiveFilter (props) {
+        const useragents = props.useragentsFilteredByQuery
+        if(useragents == null || useragents.length <= 0) return null
+        return (
+            <div className='ma3'>
+            <strong>Currently Filtered To:</strong>
+            <ul>
+              {useragents.map(useragent => <li>{ useragent.name }</li>)}
+            </ul>
+            </div>
+        )
+      }
+
+      export default connect(
+        'selectUseragentsFilteredByQuery',
+        UseragentsActiveFilter
       )
     #+END_SRC
 *** End

--- a/client/client.org
+++ b/client/client.org
@@ -377,7 +377,7 @@ A good example of this can be found in our Colours bundle.
         }
       })
 
-      bundle.reactEndpointsFetch = createSelector(
+      bundle.reactEndpointsResourceFetch = createSelector(
         'selectEndpointsResourceShouldUpdate',
         (shouldUpdate, currentReleaseId) => {
           if (!shouldUpdate) return
@@ -1529,7 +1529,7 @@ k*** Selector
         }
       })
 
-      bundle.reactUseragentsFetch = createSelector(
+      bundle.reactUseragentsResourceFetch = createSelector(
         'selectUseragentsResourceShouldUpdate',
         (shouldUpdate, currentReleaseId) => {
           if (!shouldUpdate) return

--- a/client/client.org
+++ b/client/client.org
@@ -1616,9 +1616,13 @@ k*** Selector
        })
        it('should handle USERAGENT_INPUT_UPDATED', () => {
          const payload = 'k^sjdj'
+         const payload2 = '(./a(sjd)*'
          const action = {type: 'USERAGENT_INPUT_UPDATED', payload}
+         const action2 = {type: 'USERAGENT_INPUT_UPDATED', payload}
          const result = {filterInput: payload}
+         const result2 = {filterInput: payload2}
          Reducer(useragents.getReducer()).expect(action).toReturnState(result)
+         Reducer(useragents.getReducer()).expect(action2).toReturnState(result2)
        })
      #+END_SRC
 

--- a/client/client.org
+++ b/client/client.org
@@ -412,8 +412,7 @@ A good example of this can be found in our Colours bundle.
       import {
         groupBy,
         keyBy,
-        mapValues,
-        some } from 'lodash'
+        mapValues } from 'lodash'
 
       import { calculateCoverage } from '../lib/utils.js'
 
@@ -1699,7 +1698,7 @@ k*** Selector
          'selectUseragentsInput',
          (useragents, input) => {
            var useragentsNames = map(useragents, 'name')
-           if (input === '') return useragentsNames
+           if (input === '') return []
 
            return useragentsNames.filter(ua => {
              var inputAsRegex = new RegExp(input)
@@ -2827,6 +2826,100 @@ The interior label was a bit tricky to do, and it has some logic put in that i d
     Since we loading just the info for a particular release, it's far less overhead, so we can do things like add _all_ the tests to our reducer, and then just select the ones that matter to us...but their entire object.   Since this is just a basic filter, it still ends up fast.  Neat!
 
     When you click on a test it should add it to our query.   Then, the query learns to look for whether there is a Test showing and if so, to display the active test detail.
+*** Useragent Search Container
+    :PROPERTIES:
+    :header-args: :tangle ./src/components/useragent-search-container.js
+    :END:
+
+     A container, that sits below our releases and has a search bar displayed.  When you type into it, it shows the result of yoru regex filter below, by displaying the useragents that fit that filter
+
+    #+NAME: Useragent Search Container
+    #+BEGIN_SRC js
+      import React from 'react'
+      import { connect } from 'redux-bundler-react'
+      import UseragentSearchBar from './useragent-search-bar'
+      import UseragentSearchResults from './useragent-search-results'
+
+      function UseragentSearchContainer (props) {
+        return (
+          <div id='useragent-search'>
+            <UseragentSearchBar />
+            <UseragentSearchResults />
+          </div>
+        )
+      }
+      export default connect(
+        UseragentSearchContainer
+      )
+    #+END_SRC
+*** Useragent Search Bar
+    :PROPERTIES:
+    :header-args: :tangle ./src/components/useragent-search-bar.js
+    :END:
+    #+BEGIN_SRC js
+      import React from 'react'
+      import {connect} from 'redux-bundler-react'
+
+      function UseragentSearchBar (props) {
+        const {
+          doUpdateUseragentsInput,
+          doUpdateQuery
+         } = props
+
+        return (
+            <form onInput={handleInput} onSubmit={handleSubmit}>
+            <input name='ua-filter' type='text' />
+            <input type='submit' value='submit' />
+            </form>
+            )
+
+        function handleInput (e) {
+          doUpdateUseragentsInput(e.target.value)
+        }
+        function handleSubmit (e) {
+          e.preventDefault()
+          console.log(e.target)
+          doUpdateQuery({
+            useragent: e.target.value
+          })
+        }
+      }
+
+      export default connect(
+        'doUpdateUseragentsInput',
+        'doUpdateQuery',
+        UseragentSearchBar
+      )
+
+
+
+    #+END_SRC
+*** Useragent Search Results
+    :PROPERTIES:
+    :header-args: :tangle ./src/components/useragent-search-results.js
+    :END:
+    #+BEGIN_SRC js
+      import React from 'react'
+      import {connect} from 'redux-bundler-react'
+
+      function UseragentSearchResults (props) {
+        const useragents = props.useragentsFilteredByInput
+        if(useragents == null || useragents.length <= 0) return null
+        return (
+            <ul>
+              {useragents.map(useragent => <li>{ useragent }</li>)}
+            </ul>
+        )
+      }
+
+      export default connect(
+        'selectUseragentsFilteredByInput',
+        UseragentSearchResults
+      )
+    #+END_SRC
+*** End
+
+
 ** Pages
 *** Main Page
    :PROPERTIES:
@@ -2839,6 +2932,7 @@ The interior label was a bit tricky to do, and it has some logic put in that i d
 
      // import FilterContainer from '../components/filter-container' # a regex filter for endpoints.
      import ReleasesContainer from '../components/releases-container'
+     import UseragentSearchContainer from '../components/useragent-search-container'
      import SunburstAndSummary from '../components/sunburst-and-summary'
      import ActiveTestsList from '../components/active-tests-list'
      import ActiveTestSequence from '../components/active-test-sequence'
@@ -2848,6 +2942,7 @@ The interior label was a bit tricky to do, and it has some logic put in that i d
            <main id='main-splash' className='min-vh-80 pa4 ma4 flex flex-column'>
            {/*<FilterContainer />*/}
            <ReleasesContainer />
+           <UseragentSearchContainer />
            <SunburstAndSummary />
            <ActiveTestsList />
            <ActiveTestSequence />

--- a/client/client.org
+++ b/client/client.org
@@ -958,6 +958,7 @@ When running this with just a useragent filter, I get 900 results in 'selectEndp
               store.doMarkCurrentReleaseAsOutdated()
               store.doMarkEndpointsResourceAsOutdated()
               store.doMarkTestsResourceAsOutdated()
+              store.doMarkUseragentsResourceAsOutdated()
             }
           )
         },

--- a/client/client.org
+++ b/client/client.org
@@ -666,11 +666,14 @@ A good example of this can be found in our Colours bundle.
            depth: "endpoint"
          }
 
+         // setup our useragent sample
+         var uaEndpoints_sample = []
+
          var filterResult = endpoints.selectFilteredAndZoomedEndpoints.resultFunc
-         expect(filterResult(endpointsSample, toLevel).length).toEqual(expectedLength.toLevel)
-         expect(filterResult(endpointsSample, toCategory).length).toEqual(expectedLength.toCategory)
-         expect(filterResult(endpointsSample, toEndpoint).length).toEqual(expectedLength.toEndpoint)
-         expect(filterResult(endpointsSample).length).toEqual(expectedLength.none)
+         expect(filterResult(endpointsSample, toLevel, uaEndpoints_sample).length).toEqual(expectedLength.toLevel)
+         expect(filterResult(endpointsSample, toCategory, uaEndpoints_sample).length).toEqual(expectedLength.toCategory)
+         expect(filterResult(endpointsSample, toEndpoint, uaEndpoints_sample).length).toEqual(expectedLength.toEndpoint)
+         expect(filterResult(endpointsSample, null, null).length).toEqual(expectedLength.none)
        })
 
      #+END_SRC
@@ -690,7 +693,7 @@ A good example of this can be found in our Colours bundle.
                endpoints = endpoints.filter(endpoint => endpoint.level === zoom.level)
              }
            }
-           if (uaEndpoints.length) {
+           if (uaEndpoints && uaEndpoints.length) {
              endpoints = endpoints.filter(ep => uaEndpoints.some(ua => ua.name === ep.name && ua.method === ep.method))
            }
            return endpoints
@@ -1526,13 +1529,15 @@ k*** Selector
         }
       })
 
-      bundle.reactUseragentsResourceFetch = createSelector(
+      bundle.reactUseragentsFetch = createSelector(
         'selectUseragentsResourceShouldUpdate',
         (shouldUpdate, currentReleaseId) => {
           if (!shouldUpdate) return
           return { actionCreator: 'doFetchUseragentsResource' }
         }
       )
+
+      export default bundle
 
       function fetchUseragentsByReleaseName (client, releaseName) {
         return client.service('useragents').find({
@@ -1542,7 +1547,6 @@ k*** Selector
         })
       }
 
-      export default bundle
     #+END_SRC
 *** Useragents
     :PROPERTIES:

--- a/client/client.org
+++ b/client/client.org
@@ -1970,10 +1970,15 @@ k*** Selector
       import Footer from './footer'
 
       export default connect(
+        'selectMasterRelease',
+        'selectRouteInfo',
         'doUpdateUrl',
         'selectRoute',
-        ({ doUpdateUrl, route }) => {
+        ({ masterRelease, routeInfo, doUpdateUrl, doReplaceUrl, route }) => {
           const CurrentPage = route
+          if (masterRelease && routeInfo.url === '/') {
+            doUpdateUrl(`/${masterRelease.name}`)
+          }
           return (
               <div onClick={navHelper(doUpdateUrl)}>
               <Header />
@@ -2044,7 +2049,8 @@ k*** Selector
           Page: selectPage
         }),
         {fetchEndpoints,
-         fetchTests: doFetchTests
+         fetchTests,
+         fetchUseragents
         })(App)
     #+END_SRC
 *** Footer

--- a/client/client.org
+++ b/client/client.org
@@ -2961,7 +2961,7 @@ The interior label was a bit tricky to do, and it has some logic put in that i d
         UseragentSearchResults
       )
     #+END_SRC
-*** Useragents Filter Selection
+*** Useragents Active Filter
     :PROPERTIES:
     :header-args: :tangle ./src/components/useragents-active-filter.js
     :END:

--- a/client/client.org
+++ b/client/client.org
@@ -1618,15 +1618,18 @@ k*** Selector
        it('should have initial state', () => {
          expect(state.useragents).toEqual(initialState)
        })
-       it('should handle USERAGENT_INPUT_UPDATED', () => {
-         const payload = 'k^sjdj'
-         const payload2 = '(./a(sjd)*'
+       it('should handle USERAGENT_INPUT_UPDATED with alphanumeric', () => {
+         const payload = 'ksjdj'
          const action = {type: 'USERAGENT_INPUT_UPDATED', payload}
-         const action2 = {type: 'USERAGENT_INPUT_UPDATED', payload}
          const result = {filterInput: payload}
-         const result2 = {filterInput: payload2}
          Reducer(useragents.getReducer()).expect(action).toReturnState(result)
-         Reducer(useragents.getReducer()).expect(action2).toReturnState(result2)
+       })
+
+       it('should handle USERAGENT_INPUT_UPDATED with full regex', () => {
+         const payload = '(./a(sjd)*'
+         const action = {type: 'USERAGENT_INPUT_UPDATED', payload}
+         const result = {filterInput: payload}
+         Reducer(useragents.getReducer()).expect(action).toReturnState(result)
        })
      #+END_SRC
 

--- a/client/client.org
+++ b/client/client.org
@@ -2461,7 +2461,7 @@ We are being passed a big chunk of data for releases, drawing from the metadata 
           var rawQuery = {
             level: path[1],
             category: path[2],
-            name: path[3],
+            name: path[3]
           }
           var query = propertiesWithValue(rawQuery)
           if (queryObject.zoomed) {
@@ -2469,6 +2469,9 @@ We are being passed a big chunk of data for releases, drawing from the metadata 
           }
           if (queryObject.filter) {
             query.filter = queryObject.filter
+          }
+          if (queryObject.useragents) {
+            query.useragents = queryObject.useragents
           }
           doUpdateQuery(query)
         }
@@ -2480,6 +2483,9 @@ We are being passed a big chunk of data for releases, drawing from the metadata 
           }
           if (queryObject.zoomed) {
             query.zoomed = queryObject.zoomed
+          }
+          if (queryObject.useragents) {
+            query.useragents = queryObject.useragents
           }
           doUpdateQuery(query)
         }
@@ -2499,15 +2505,22 @@ We are being passed a big chunk of data for releases, drawing from the metadata 
           if (queryObject.filter) {
             query.filter = queryObject.filter
           }
+          if (queryObject.useragents) {
+            query.useragents = queryObject.useragents
+          }
+
           doUpdateQuery(query)
         }
 
         function handleReset () {
+          var query = {}
           if (queryObject.filter) {
-            doUpdateQuery({filter: queryObject.filter})
-          } else {
-            doUpdateQuery({})
+            query.filter = queryObject.filter
           }
+          if (queryObject.useragents) {
+            query.useragents =queryObject.useragents
+          }
+          doUpdateQuery(query)
         }
 
         function getKeyPath (node) {

--- a/client/client.org
+++ b/client/client.org
@@ -1974,7 +1974,7 @@ k*** Selector
         'selectRouteInfo',
         'doUpdateUrl',
         'selectRoute',
-        ({ masterRelease, routeInfo, doUpdateUrl, doReplaceUrl, route }) => {
+        ({ masterRelease, routeInfo, doUpdateUrl, route }) => {
           const CurrentPage = route
           if (masterRelease && routeInfo.url === '/') {
             doUpdateUrl(`/${masterRelease.name}`)

--- a/client/client.org
+++ b/client/client.org
@@ -1704,6 +1704,14 @@ k*** Selector
            var useragentsNames = map(useragents, 'name')
            if (input === '') return []
 
+           var isValid = true
+           try {
+             new RegExp(input)
+           } catch (err) {
+             isValid = false
+           }
+           if (!isValid) return ['not valid regex']
+
            return useragentsNames.filter(ua => {
              var inputAsRegex = new RegExp(input)
              return inputAsRegex.test(ua)

--- a/client/client.org
+++ b/client/client.org
@@ -2863,12 +2863,13 @@ The interior label was a bit tricky to do, and it has some logic put in that i d
       function UseragentSearchBar (props) {
         const {
           doUpdateUseragentsInput,
-          doUpdateQuery
+          doUpdateQuery,
+          useragentsInput
          } = props
 
         return (
-            <form onInput={handleInput} onSubmit={handleSubmit}>
-            <input name='ua-filter' type='text' />
+            <form onSubmit={handleSubmit}>
+            <input name='ua-filter' type='text' value={useragentsInput} onChange={handleInput}/>
             <input type='submit' value='submit' />
             </form>
             )
@@ -2878,16 +2879,18 @@ The interior label was a bit tricky to do, and it has some logic put in that i d
         }
         function handleSubmit (e) {
           e.preventDefault()
-          console.log(e.target)
           doUpdateQuery({
-            useragent: e.target.value
+            useragent: e.target[0].value
           })
+          doUpdateUseragentsInput('')
+
         }
       }
 
       export default connect(
         'doUpdateUseragentsInput',
         'doUpdateQuery',
+        'selectUseragentsInput',
         UseragentSearchBar
       )
 

--- a/client/src/bundles/endpoints-resource.js
+++ b/client/src/bundles/endpoints-resource.js
@@ -8,7 +8,7 @@ const bundle = createAsyncResourceBundle({
   }
 })
 
-bundle.reactEndpointsFetch = createSelector(
+bundle.reactEndpointsResourceFetch = createSelector(
   'selectEndpointsResourceShouldUpdate',
   (shouldUpdate, currentReleaseId) => {
     if (!shouldUpdate) return

--- a/client/src/bundles/endpoints.js
+++ b/client/src/bundles/endpoints.js
@@ -33,7 +33,7 @@ export default {
             endpoints = endpoints.filter(endpoint => endpoint.level === zoom.level)
           }
         }
-        if (uaEndpoints.length) {
+        if (uaEndpoints && uaEndpoints.length) {
           endpoints = endpoints.filter(ep => uaEndpoints.some(ua => ua.name === ep.name && ua.method === ep.method))
         }
         return endpoints

--- a/client/src/bundles/endpoints.js
+++ b/client/src/bundles/endpoints.js
@@ -2,8 +2,7 @@ import { createSelector } from 'redux-bundler'
 import {
   groupBy,
   keyBy,
-  mapValues,
-  some } from 'lodash'
+  mapValues } from 'lodash'
 
 import { calculateCoverage } from '../lib/utils.js'
 

--- a/client/src/bundles/endpoints.test.js
+++ b/client/src/bundles/endpoints.test.js
@@ -176,11 +176,14 @@ describe('Endpoints Selectors', () => {
       depth: "endpoint"
     }
   
+    // setup our useragent sample
+    var uaEndpoints_sample = []
+  
     var filterResult = endpoints.selectFilteredAndZoomedEndpoints.resultFunc
-    expect(filterResult(endpointsSample, toLevel).length).toEqual(expectedLength.toLevel)
-    expect(filterResult(endpointsSample, toCategory).length).toEqual(expectedLength.toCategory)
-    expect(filterResult(endpointsSample, toEndpoint).length).toEqual(expectedLength.toEndpoint)
-    expect(filterResult(endpointsSample).length).toEqual(expectedLength.none)
+    expect(filterResult(endpointsSample, toLevel, uaEndpoints_sample).length).toEqual(expectedLength.toLevel)
+    expect(filterResult(endpointsSample, toCategory, uaEndpoints_sample).length).toEqual(expectedLength.toCategory)
+    expect(filterResult(endpointsSample, toEndpoint, uaEndpoints_sample).length).toEqual(expectedLength.toEndpoint)
+    expect(filterResult(endpointsSample, null, null).length).toEqual(expectedLength.none)
   })
   
   var zoomDepthCategory = {

--- a/client/src/bundles/releases.js
+++ b/client/src/bundles/releases.js
@@ -14,6 +14,7 @@ export default {
         store.doMarkCurrentReleaseAsOutdated()
         store.doMarkEndpointsResourceAsOutdated()
         store.doMarkTestsResourceAsOutdated()
+        store.doMarkUseragentsResourceAsOutdated()
       }
     )
   },

--- a/client/src/bundles/useragents-resource.js
+++ b/client/src/bundles/useragents-resource.js
@@ -8,13 +8,15 @@ const bundle = createAsyncResourceBundle({
   }
 })
 
-bundle.reactUseragentsResourceFetch = createSelector(
+bundle.reactUseragentsFetch = createSelector(
   'selectUseragentsResourceShouldUpdate',
   (shouldUpdate, currentReleaseId) => {
     if (!shouldUpdate) return
     return { actionCreator: 'doFetchUseragentsResource' }
   }
 )
+
+export default bundle
 
 function fetchUseragentsByReleaseName (client, releaseName) {
   return client.service('useragents').find({
@@ -23,5 +25,3 @@ function fetchUseragentsByReleaseName (client, releaseName) {
     }
   })
 }
-
-export default bundle

--- a/client/src/bundles/useragents-resource.js
+++ b/client/src/bundles/useragents-resource.js
@@ -8,7 +8,7 @@ const bundle = createAsyncResourceBundle({
   }
 })
 
-bundle.reactUseragentsFetch = createSelector(
+bundle.reactUseragentsResourceFetch = createSelector(
   'selectUseragentsResourceShouldUpdate',
   (shouldUpdate, currentReleaseId) => {
     if (!shouldUpdate) return

--- a/client/src/bundles/useragents.js
+++ b/client/src/bundles/useragents.js
@@ -21,7 +21,7 @@ export default {
     'selectUseragentsInput',
     (useragents, input) => {
       var useragentsNames = map(useragents, 'name')
-      if (input === '') return useragentsNames
+      if (input === '') return []
   
       return useragentsNames.filter(ua => {
         var inputAsRegex = new RegExp(input)

--- a/client/src/bundles/useragents.js
+++ b/client/src/bundles/useragents.js
@@ -35,9 +35,9 @@ export default {
     'selectQueryObject',
     (useragents, query) => {
       if (useragents == null || !query) return []
-      if (query.useragent && query.useragent.length) {
+      if (query.useragents && query.useragents.length) {
         return filter(useragents, (ua) => {
-          var inputAsRegex = new RegExp(query.useragent)
+          var inputAsRegex = new RegExp(query.useragents)
           return inputAsRegex.test(ua.name)
         })
       } else {

--- a/client/src/bundles/useragents.js
+++ b/client/src/bundles/useragents.js
@@ -23,6 +23,14 @@ export default {
       var useragentsNames = map(useragents, 'name')
       if (input === '') return []
   
+      var isValid = true
+      try {
+        new RegExp(input)
+      } catch (err) {
+        isValid = false
+      }
+      if (!isValid) return ['not valid regex']
+  
       return useragentsNames.filter(ua => {
         var inputAsRegex = new RegExp(input)
         return inputAsRegex.test(ua)

--- a/client/src/components/app.js
+++ b/client/src/components/app.js
@@ -6,10 +6,16 @@ import Header from './header'
 import Footer from './footer'
 
 export default connect(
+  'selectMasterRelease',
+  'selectRouteInfo',
   'doUpdateUrl',
   'selectRoute',
-  ({ doUpdateUrl, route }) => {
+  ({ masterRelease, routeInfo, doUpdateUrl, doReplaceUrl, route }) => {
     const CurrentPage = route
+    if (masterRelease && routeInfo.url === '/') {
+      doUpdateUrl(`/${masterRelease.name}`)
+      return null
+    }
     return (
         <div onClick={navHelper(doUpdateUrl)}>
         <Header />

--- a/client/src/components/sunburst.js
+++ b/client/src/components/sunburst.js
@@ -50,7 +50,7 @@ const SunburstChart = (props) => {
     var rawQuery = {
       level: path[1],
       category: path[2],
-      name: path[3],
+      name: path[3]
     }
     var query = propertiesWithValue(rawQuery)
     if (queryObject.zoomed) {
@@ -58,6 +58,9 @@ const SunburstChart = (props) => {
     }
     if (queryObject.filter) {
       query.filter = queryObject.filter
+    }
+    if (queryObject.useragents) {
+      query.useragents = queryObject.useragents
     }
     doUpdateQuery(query)
   }
@@ -69,6 +72,9 @@ const SunburstChart = (props) => {
     }
     if (queryObject.zoomed) {
       query.zoomed = queryObject.zoomed
+    }
+    if (queryObject.useragents) {
+      query.useragents = queryObject.useragents
     }
     doUpdateQuery(query)
   }
@@ -88,15 +94,22 @@ const SunburstChart = (props) => {
     if (queryObject.filter) {
       query.filter = queryObject.filter
     }
+    if (queryObject.useragents) {
+      query.useragents = queryObject.useragents
+    }
+
     doUpdateQuery(query)
   }
 
   function handleReset () {
+    var query = {}
     if (queryObject.filter) {
-      doUpdateQuery({filter: queryObject.filter})
-    } else {
-      doUpdateQuery({})
+      query.filter = queryObject.filter
     }
+    if (queryObject.useragents) {
+      query.useragents =queryObject.useragents
+    }
+    doUpdateQuery(query)
   }
 
   function getKeyPath (node) {

--- a/client/src/components/useragent-search-bar.js
+++ b/client/src/components/useragent-search-bar.js
@@ -21,7 +21,7 @@ function UseragentSearchBar (props) {
   function handleSubmit (e) {
     e.preventDefault()
     doUpdateQuery({
-      useragent: e.target[0].value
+      useragents: e.target[0].value
     })
     doUpdateUseragentsInput('')
 

--- a/client/src/components/useragent-search-bar.js
+++ b/client/src/components/useragent-search-bar.js
@@ -4,12 +4,13 @@ import {connect} from 'redux-bundler-react'
 function UseragentSearchBar (props) {
   const {
     doUpdateUseragentsInput,
-    doUpdateQuery
+    doUpdateQuery,
+    useragentsInput
    } = props
 
   return (
-      <form onInput={handleInput} onSubmit={handleSubmit}>
-      <input name='ua-filter' type='text' />
+      <form onSubmit={handleSubmit}>
+      <input name='ua-filter' type='text' value={useragentsInput} onChange={handleInput}/>
       <input type='submit' value='submit' />
       </form>
       )
@@ -19,15 +20,17 @@ function UseragentSearchBar (props) {
   }
   function handleSubmit (e) {
     e.preventDefault()
-    console.log(e.target)
     doUpdateQuery({
-      useragent: e.target.value
+      useragent: e.target[0].value
     })
+    doUpdateUseragentsInput('')
+
   }
 }
 
 export default connect(
   'doUpdateUseragentsInput',
   'doUpdateQuery',
+  'selectUseragentsInput',
   UseragentSearchBar
 )

--- a/client/src/components/useragent-search-bar.js
+++ b/client/src/components/useragent-search-bar.js
@@ -1,0 +1,33 @@
+import React from 'react'
+import {connect} from 'redux-bundler-react'
+
+function UseragentSearchBar (props) {
+  const {
+    doUpdateUseragentsInput,
+    doUpdateQuery
+   } = props
+
+  return (
+      <form onInput={handleInput} onSubmit={handleSubmit}>
+      <input name='ua-filter' type='text' />
+      <input type='submit' value='submit' />
+      </form>
+      )
+
+  function handleInput (e) {
+    doUpdateUseragentsInput(e.target.value)
+  }
+  function handleSubmit (e) {
+    e.preventDefault()
+    console.log(e.target)
+    doUpdateQuery({
+      useragent: e.target.value
+    })
+  }
+}
+
+export default connect(
+  'doUpdateUseragentsInput',
+  'doUpdateQuery',
+  UseragentSearchBar
+)

--- a/client/src/components/useragent-search-container.js
+++ b/client/src/components/useragent-search-container.js
@@ -1,0 +1,16 @@
+import React from 'react'
+import { connect } from 'redux-bundler-react'
+import UseragentSearchBar from './useragent-search-bar'
+import UseragentSearchResults from './useragent-search-results'
+
+function UseragentSearchContainer (props) {
+  return (
+    <div id='useragent-search'>
+      <UseragentSearchBar />
+      <UseragentSearchResults />
+    </div>
+  )
+}
+export default connect(
+  UseragentSearchContainer
+)

--- a/client/src/components/useragent-search-container.js
+++ b/client/src/components/useragent-search-container.js
@@ -2,12 +2,15 @@ import React from 'react'
 import { connect } from 'redux-bundler-react'
 import UseragentSearchBar from './useragent-search-bar'
 import UseragentSearchResults from './useragent-search-results'
+import UseragentsActiveFilter from './useragents-active-filter'
+
 
 function UseragentSearchContainer (props) {
   return (
     <div id='useragent-search'>
       <UseragentSearchBar />
       <UseragentSearchResults />
+      <UseragentsActiveFilter />
     </div>
   )
 }

--- a/client/src/components/useragent-search-results.js
+++ b/client/src/components/useragent-search-results.js
@@ -1,0 +1,17 @@
+import React from 'react'
+import {connect} from 'redux-bundler-react'
+
+function UseragentSearchResults (props) {
+  const useragents = props.useragentsFilteredByInput
+  if(useragents == null || useragents.length <= 0) return null
+  return (
+      <ul>
+        {useragents.map(useragent => <li>{ useragent }</li>)}
+      </ul>
+  )
+}
+
+export default connect(
+  'selectUseragentsFilteredByInput',
+  UseragentSearchResults
+)

--- a/client/src/components/useragent-search-results.js
+++ b/client/src/components/useragent-search-results.js
@@ -5,9 +5,12 @@ function UseragentSearchResults (props) {
   const useragents = props.useragentsFilteredByInput
   if(useragents == null || useragents.length <= 0) return null
   return (
-      <ul>
-        {useragents.map(useragent => <li>{ useragent }</li>)}
+    <div id='useragent-search-results' className='mt2 mb0'>
+      <strong className='f5'>Useragents covered by this regex</strong>
+      <ul className="list ph0">
+        {useragents.map(useragent => <li key={useragent} className="f6 dib mr2 pa2 mid-gray">{ useragent }</li>)}
       </ul>
+    </div>
   )
 }
 

--- a/client/src/components/useragents-active-filter.js
+++ b/client/src/components/useragents-active-filter.js
@@ -1,0 +1,20 @@
+import React from 'react'
+import {connect} from 'redux-bundler-react'
+
+function UseragentsActiveFilter (props) {
+  const useragents = props.useragentsFilteredByQuery
+  if(useragents == null || useragents.length <= 0) return null
+  return (
+      <div className='ma3'>
+      <strong>Currently Filtered To:</strong>
+      <ul>
+        {useragents.map(useragent => <li>{ useragent.name }</li>)}
+      </ul>
+      </div>
+  )
+}
+
+export default connect(
+  'selectUseragentsFilteredByQuery',
+  UseragentsActiveFilter
+)

--- a/client/src/pages/main-page.js
+++ b/client/src/pages/main-page.js
@@ -3,6 +3,7 @@ import { connect } from 'redux-bundler-react'
 
 // import FilterContainer from '../components/filter-container' # a regex filter for endpoints.
 import ReleasesContainer from '../components/releases-container'
+import UseragentSearchContainer from '../components/useragent-search-container'
 import SunburstAndSummary from '../components/sunburst-and-summary'
 import ActiveTestsList from '../components/active-tests-list'
 import ActiveTestSequence from '../components/active-test-sequence'
@@ -11,6 +12,7 @@ function MainPage () {
     return (
       <main id='main-splash' className='min-vh-80 pa4 ma4 flex flex-column'>
       {/*<FilterContainer />*/}
+      <UseragentSearchContainer />
       <ReleasesContainer />
       <SunburstAndSummary />
       <ActiveTestsList />

--- a/client/src/pages/main-page.js
+++ b/client/src/pages/main-page.js
@@ -12,8 +12,8 @@ function MainPage () {
     return (
       <main id='main-splash' className='min-vh-80 pa4 ma4 flex flex-column'>
       {/*<FilterContainer />*/}
-      <UseragentSearchContainer />
       <ReleasesContainer />
+      <UseragentSearchContainer />
       <SunburstAndSummary />
       <ActiveTestsList />
       <ActiveTestSequence />

--- a/src/app.js
+++ b/src/app.js
@@ -30,6 +30,10 @@ app.use(express.urlencoded({ extended: true }));
 app.use(favicon(path.join(app.get('public'), 'favicon.ico')));
 // Host the public folder
 app.use('/', express.static(app.get('public')));
+app.get(/^\/ci.*/, function(req,res){
+  res.sendFile(path.join(__dirname,
+                         '../public', 'index.html'));
+})
 
 // Set up Plugins and providers
 app.configure(express.rest());


### PR DESCRIPTION
```release-note
Search Bar for Filtering User-Agents!
```

This pull request implements work laid out in #121, #122 , #123 , #124 , #125 , and #134 .  This is meant as a Proof of Concept, and its implementation and UX will be refined after conversation and review.

The current flow is that you can type a regex query into the useragent search, and see a list of useragent's available in this releases data set that match the query.  When you submit your query, all the endpoints filter to those that were hit by this useragent.  Since the Useragent's are added as part of e2e testing, anytime you filter the endpoints will show as 100% tested, with the color difference being whether they are tested by Conformance or not. 