### PR TITLE
ci/cd: move CI dependency script outside of package.json

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -1,0 +1,19 @@
+#! /bin/sh
+set -exo
+set -u pipefail
+
+
+if CI=true; then
+  curl https://storage.googleapis.com/pub/gsutil.tar.gz | tar xfz - \
+    ; wget -O jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 \
+    ; chmod +x ./jq ; mkdir bin ; mv jq bin/ \
+    ; curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py \
+    ;  python get-pip.py --user ; export PATH=$PWD/gsutil:$PWD/bin:/app/.local/bin:$PATH \
+    ; pip install --user yq \
+    ; ./apisnoop.sh --download-apiusage \
+    ; cd client && npm install && npm run build
+else
+  echo "$CI != true, so skipping installation of dependencies. "
+  ./apisnoop.sh --download-apiusage
+  cd client && npm install && npm run build
+fi

--- a/ci.sh
+++ b/ci.sh
@@ -4,14 +4,15 @@ set -u pipefail
 
 
 if CI=true; then
-  curl https://storage.googleapis.com/pub/gsutil.tar.gz | tar xfz - \
-    ; wget -O jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 \
-    ; chmod +x ./jq ; mkdir bin ; mv jq bin/ \
-    ; curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py \
-    ;  python get-pip.py --user ; export PATH=$PWD/gsutil:$PWD/bin:/app/.local/bin:$PATH \
-    ; pip install --user yq \
-    ; ./apisnoop.sh --download-apiusage \
-    ; cd client && npm install && npm run build
+  curl https://storage.googleapis.com/pub/gsutil.tar.gz | tar xfz -
+  wget -O jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64
+  chmod +x ./jq ; mkdir bin ; mv jq bin/
+  curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+  python get-pip.py --user
+  export PATH=$PWD/gsutil:$PWD/bin:/app/.local/bin:$PATH
+  pip install --user yq
+  ./apisnoop.sh --download-apiusage
+  cd client && npm install && npm run build
 else
   echo "$CI != true, so skipping installation of dependencies. "
   ./apisnoop.sh --download-apiusage

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "npm": ">= 3.0.0"
   },
   "scripts": {
-    "postinstall": "curl https://storage.googleapis.com/pub/gsutil.tar.gz | tar xfz - ; wget -O jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64  ; chmod +x ./jq ; mkdir bin ; mv jq bin/ ; curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py ;  python get-pip.py --user ; export PATH=$PWD/gsutil:$PWD/bin:/app/.local/bin:$PATH ; pip install --user yq ; ./apisnoop.sh --download-apiusage ; cd client && npm install && npm run build",
+    "postinstall": "sh ./ci.sh",
     "dev": "nodemon --ignore 'client/*' src/",
     "start": "node src/"
   },


### PR DESCRIPTION
```release-note
This moves our script to install dependencies for CI, outside of
package.json, and also adds an if statement to only install deps if $CI
= true
```

https://github.com/cncf/apisnoop/issues/143