### PR TITLE
Dynamic buckets

### DIFF
--- a/app/app.org
+++ b/app/app.org
@@ -607,12 +607,12 @@ The downside of this is that apisnoop developers should be doing it from within 
      export default {
        name: 'config',
        reducer: (state = config) => state,
-       selectConfig: (state) => state.config,
-       selectConfigTwo: (state) => state.configResource.data,
+       selectConfigDUMP: (state) => state.config,
+       selectConfig: (state) => state.configResource.data,
        selectProvider: (state) => state.config.provider,
        selectGsBucket: createSelector(
          'selectProvider',
-         'selectConfigTwo',
+         'selectConfig',
          (provider, config) => {
            let gsBucket;
            if  (config == null || config['gs-bucket'] === undefined) return gsBucket;
@@ -621,7 +621,7 @@ The downside of this is that apisnoop developers should be doing it from within 
          }
        ),
        selectDefaultBucketJob: createSelector(
-         'selectConfigTwo',
+         'selectConfig',
          'selectGsBucket',
          (config, gsBucket) => {
            let defaultBucketJob, bucket, job = '';
@@ -650,6 +650,33 @@ The downside of this is that apisnoop developers should be doing it from within 
 **
 
 ** BucketList
+  :PROPERTIES:
+    :header-args: :tangle ./src/bundles/bucket-list.js :noweb yes
+    :END:
+
+  Manages the list of buckets from our config, to populate our BucketList component
+
+**** Imports and Export
+    #+NAME: Buckets bundle
+    #+BEGIN_SRC js
+      import { createSelector } from 'redux-bundler'
+
+      export default {
+        name: 'bucketList',
+        <<selectBuckets>>
+      }
+    #+END_SRC
+
+**** selectBuckets
+     **Config -> BucketObject**
+     //Brings out the bucket key from our config//
+     #+NAME: selectBuckets
+     #+BEGIN_SRC js :tangle no
+
+
+     #+END_SRC
+
+
 ** Endpoints
   :PROPERTIES:
     :header-args: :tangle ./src/bundles/endpoints.js :noweb yes
@@ -1122,7 +1149,7 @@ The downside of this is that apisnoop developers should be doing it from within 
     #+NAME: selectBucket
     #+BEGIN_SRC js :tangle no
       selectBucket: createSelector(
-        'selectConfig',
+        'selectConfigDUMP',
         'selectQueryObject',
         (config, query) => {
           let bucket = ''

--- a/app/app.org
+++ b/app/app.org
@@ -239,6 +239,7 @@ The downside of this is that apisnoop developers should be doing it from within 
       import { composeBundles } from 'redux-bundler'
 
       import activeLocation from './active-location'
+      import bucketList from './bucket-list'
       import colours from './colours'
       import config from './config'
       import configResource from './config-resource'
@@ -260,6 +261,7 @@ The downside of this is that apisnoop developers should be doing it from within 
 
       export default composeBundles(
         activeLocation,
+        bucketList,
         colours,
         config,
         configResource,
@@ -646,9 +648,6 @@ The downside of this is that apisnoop developers should be doing it from within 
        )
      }
    #+END_SRC
-
-**
-
 ** BucketList
   :PROPERTIES:
     :header-args: :tangle ./src/bundles/bucket-list.js :noweb yes
@@ -660,20 +659,52 @@ The downside of this is that apisnoop developers should be doing it from within 
     #+NAME: Buckets bundle
     #+BEGIN_SRC js
       import { createSelector } from 'redux-bundler'
+      import { flatten, map } from 'lodash'
 
       export default {
         name: 'bucketList',
-        <<selectBuckets>>
+        <<selectBuckets>>,
+        <<selectBucketJobPaths>>
       }
     #+END_SRC
 
 **** selectBuckets
-     **Config -> BucketObject**
+     **Config -> ◊BucketObject**
      //Brings out the bucket key from our config//
      #+NAME: selectBuckets
      #+BEGIN_SRC js :tangle no
+       selectBuckets: createSelector(
+         'selectConfig',
+         (config) => {
+           let buckets = {};
+           if (!config || !config.buckets) return buckets
+           buckets = config.buckets
+           return buckets
+         }
+       )
 
+     #+END_SRC
 
+**** selectBucketJobPaths
+     ** ◊BucketObject ◊GsBucket-> BucketJobPathList**
+     // Returns an array of BucketJobPaths to feed our bucketlist component//
+     #+NAME: selectBucketJobPaths
+     #+BEGIN_SRC js :tangle no
+       selectBucketJobPaths: createSelector(
+         'selectGsBucket',
+         'selectBuckets',
+         (gsBucket, buckets) => {
+           let bucketJobPaths = [];
+           if (!gsBucket || !buckets) return bucketJobPaths
+           bucketJobPaths = map(buckets, (value, key) => {
+             let bucket = key;
+             let paths = [];
+             value['jobs'].forEach(job => paths.push([gsBucket, bucket, job].join('/')))
+             return paths
+           })
+           return flatten(bucketJobPaths)
+         }
+       )
      #+END_SRC
 
 
@@ -2394,71 +2425,71 @@ The downside of this is that apisnoop developers should be doing it from within 
 
    #+NAME: BucketList
    #+BEGIN_SRC js
-          import React from 'react'
-          import { connect } from 'redux-bundler-react'
+     import React from 'react'
+     import { connect } from 'redux-bundler-react'
 
 
-          function BucketList (props) {
-            let buckets = [
-                'ci-kubernetes-e2e-gce-cos-k8sstable3-default/1121083339638312961',
-                'ci-kubernetes-e2e-gce-cos-k8sstable2-default/1121457989778149377',
-                'ci-kubernetes-e2e-gce-cos-k8sstable1-default/1121581392354873344',
-                'ci-kubernetes-e2e-gce-cos-k8sbeta-default/1121564030004105216',
-                'ci-kubernetes-e2e-gci-gce/1121334929389522946',
-            ]
+     function BucketList (props) {
+       let buckets = [
+           'ci-kubernetes-e2e-gce-cos-k8sstable3-default/1121083339638312961',
+           'ci-kubernetes-e2e-gce-cos-k8sstable2-default/1121457989778149377',
+           'ci-kubernetes-e2e-gce-cos-k8sstable1-default/1121581392354873344',
+           'ci-kubernetes-e2e-gce-cos-k8sbeta-default/1121564030004105216',
+           'ci-kubernetes-e2e-gci-gce/1121334929389522946',
+       ]
 
-            const { doUpdateQuery,
-                    doMarkEndpointsResourceAsOutdated,
-                    doMarkMetadataResourceAsOutdated,
-                    doMarkTestsResourceAsOutdated,
-                    doMarkTestSequencesResourceAsOutdated,
-                    doMarkTestTagsResourceAsOutdated,
-                    doMarkUseragentsResourceAsOutdated,
-                    bucket
-                  } = props
-            return (
-                <div id='bucket-list'>
-                <h2>Select a Bucket</h2>
-                <ul className="list flex flex-wrap pl0">
-                {buckets.map((b, i) => {
-                  return (
-                      <li className='pr2 pb2' key={`bucket_${i}`}>
-                      {(b === bucket) &&
-                          <button onClick={handleClick}
-                        className='f6 link dim ba b--black ph3 pv2 mb2 dib black bg-washed-red magic-pointer'>{b}</button>}
-                      {(b !== bucket) && <button onClick={handleClick}
-                        className='f6 link dim ba b--black ph3 pv2 mb2 dib black bg-transparent magic-pointer'>{b}</button>}
-                      </li>)
-                })}
-              </ul>
-                </div>
-            )
+       const { doUpdateQuery,
+               doMarkEndpointsResourceAsOutdated,
+               doMarkMetadataResourceAsOutdated,
+               doMarkTestsResourceAsOutdated,
+               doMarkTestSequencesResourceAsOutdated,
+               doMarkTestTagsResourceAsOutdated,
+               doMarkUseragentsResourceAsOutdated,
+               bucketJobPaths,
+               bucket
+             } = props
+       return (
+           <div id='bucket-list'>
+           <h2>Select a Bucket</h2>
+           <ul className="list flex flex-wrap pl0">
+           {bucketJobPaths.map((b, i) => {
+             return (
+                 <li className='pr2 pb2' key={`bucket_${i}`}>
+                 {(b === bucket) &&
+                     <button onClick={handleClick}
+                   className='f6 link dim ba b--black ph3 pv2 mb2 dib black bg-washed-red magic-pointer'>{b}</button>}
+                 {(b !== bucket) && <button onClick={handleClick}
+                   className='f6 link dim ba b--black ph3 pv2 mb2 dib black bg-transparent magic-pointer'>{b}</button>}
+                 </li>)
+           })}
+         </ul>
+           </div>
+       )
 
-            function handleClick (e) {
-              let storagePath = 'apisnoop/default/'
-              let bucket = e.target.innerHTML
-              let fullPath = storagePath.concat(bucket)
-              doMarkEndpointsResourceAsOutdated()
-              doMarkTestsResourceAsOutdated()
-              doMarkTestSequencesResourceAsOutdated()
-              doMarkTestTagsResourceAsOutdated()
-              doMarkMetadataResourceAsOutdated()
-              doMarkUseragentsResourceAsOutdated()
-              doUpdateQuery({bucket: fullPath})
-            }
-          }
+       function handleClick (e) {
+         let bucket = e.target.textContent
+         doMarkEndpointsResourceAsOutdated()
+         doMarkTestsResourceAsOutdated()
+         doMarkTestSequencesResourceAsOutdated()
+         doMarkTestTagsResourceAsOutdated()
+         doMarkMetadataResourceAsOutdated()
+         doMarkUseragentsResourceAsOutdated()
+         doUpdateQuery({bucket: bucket})
+       }
+     }
 
-          export default connect(
-            'doUpdateQuery',
-            'doMarkEndpointsResourceAsOutdated',
-            'doMarkTestsResourceAsOutdated',
-            'doMarkMetadataResourceAsOutdated',
-            'doMarkTestSequencesResourceAsOutdated',
-            'doMarkTestTagsResourceAsOutdated',
-            'doMarkUseragentsResourceAsOutdated',
-            'selectBucket',
-            BucketList
-          )
+     export default connect(
+       'doUpdateQuery',
+       'doMarkEndpointsResourceAsOutdated',
+       'doMarkTestsResourceAsOutdated',
+       'doMarkMetadataResourceAsOutdated',
+       'doMarkTestSequencesResourceAsOutdated',
+       'doMarkTestTagsResourceAsOutdated',
+       'doMarkUseragentsResourceAsOutdated',
+       'selectBucket',
+       'selectBucketJobPaths',
+       BucketList
+     )
    #+END_SRC
 
 ** Summary Container
@@ -3326,6 +3357,25 @@ The downside of this is that apisnoop developers should be doing it from within 
 
    #+END_SRC
 * Data Definitions
+** BucketObject (<<<◊BucketObject>>>)
+   This is an Object containing the bucket names pulled from ◊AuditSources, and a list of the jobs within each one
+   #+NAME: BucketObject Definition Example
+   #+BEGIN_EXAMPLE js
+     {
+       BUCKETNAME: {
+         jobs: [
+           'JOBNUMBER',
+         ]
+       },
+       ci-gci-gce: {
+         jobs: [
+           '1131312121',
+           '2221313112'
+         ]
+       }
+     }
+
+   #+END_EXAMPLE
 ** ColourState (<<<◊ColourState>>>)
 
    Colourstate is an Object, consisting of colours, moreColours, and categories.
@@ -3731,7 +3781,17 @@ The downside of this is that apisnoop developers should be doing it from within 
         bucket: Bucket.name
         job: Bucket.job
   #+END_SRC
-
+** BucketJobPathList(<<<◊BucketJobPathList>>>)
+   An array of url paths to feed into our bucketlist component.
+   each BucketJobPath is =GCSBUCKET/BUCKET/JOB= , like =apisnoop/default/gci-gce-something/112112312=
+   #+NAME: BucketJobPathList Definition Example
+   #+BEGIN_SRC js
+     [
+       'apisnoop/default/gci-gce-something-or-other/11131131311' ,
+       'apisnoop/default/gci-gce-something-or-other/11131131219' ,
+       'apisnoop/default/gci-gce-something-stable/11921919119',
+     ]
+   #+END_SRC
 * Glossary
 ** Bundle (<<<bundles>>> | <<<bundle>>>)
    a collection of redux code all organized by some concern or idea.  It's a marked difference from the typical organizing style, where you organize files by what they are (reducers, selectors, etc.).  This, instead, organizes files by their topic.

--- a/app/app.org
+++ b/app/app.org
@@ -30,6 +30,11 @@ If the redux store feels like one big spreadsheet, then we are doing a good job.
     I refactor the org file more often than the code, to help future developers learn what it is we're doing and why. No important things should be held in a conversational memory, but instead linked and explained here.  The risk with this is verbosity.  So cleaning up sentence structure and explanations is as important as refactoring code.
 
 The downside of this is that apisnoop developers should be doing it from within the org file--but the strengths are strong enough to make this worthwhile I think.
+* Getting our Data
+  Apisnoop runs our data-gen processes on an audit log and then stores the results in a gs:// bucket whose folder structure mirrors the bucket and job of that audit log.  We determine which buckets and jobs to process, and where we store the processed data, using our audit-sources.yaml located in the top of the repo.  The audit-sources.yaml should match the structure outlined at ◊AuditSources
+
+  Our process log uses gsutil, and so we require the data to be on google storage.
+
 * Index.js
   :PROPERTIES:
   :header-args: :tangle ./src/index.js
@@ -236,6 +241,7 @@ The downside of this is that apisnoop developers should be doing it from within 
       import activeLocation from './active-location'
       import colours from './colours'
       import config from './config'
+      import configResource from './config-resource'
       import endpoints from './endpoints'
       import endpointsResource from './endpoints-resource'
       import metadataResource from './metadata-resource'
@@ -256,6 +262,7 @@ The downside of this is that apisnoop developers should be doing it from within 
         activeLocation,
         colours,
         config,
+        configResource,
         endpoints,
         endpointsResource,
         metadataResource,
@@ -330,6 +337,7 @@ The downside of this is that apisnoop developers should be doing it from within 
       )
 
     #+END_SRC
+
 ** Colours
    :PROPERTIES:
    :header-args: :tangle ./src/bundles/colours.js :noweb yes
@@ -548,6 +556,36 @@ The downside of this is that apisnoop developers should be doing it from within 
 
     #+END_SRC
 
+** ConfigResource
+   :PROPERTIES:
+   :header-args: :tangle ./src/bundles/config-resource.js :noweb yes
+   :END:
+
+   Brings in the audit-sources.yaml located in our public folder to generate our storage-path and list of buckets and jobs to pull from that storage path.
+
+   #+NAME: Config Resource
+   #+BEGIN_SRC js
+     import { createAsyncResourceBundle, createSelector } from 'redux-bundler'
+     import * as yaml from 'js-yaml'
+
+     const bundle = createAsyncResourceBundle({
+       name: 'configResource',
+       getPromise: () => {
+         return fetch('audit-sources.yaml').then(response => response.text()).then(text => yaml.safeLoad(text, 'utf8'))
+       }
+     })
+
+     bundle.reactConfigResourceFetch = createSelector(
+       'selectConfigResourceShouldUpdate',
+       (shouldUpdate) => {
+         if (!shouldUpdate) return
+         return { actionCreator: 'doFetchConfigResource' }
+       }
+     )
+
+     export default bundle
+   #+END_SRC
+
 ** Config
    :PROPERTIES:
    :header-args: :tangle ./src/bundles/config.js :noweb yes
@@ -558,27 +596,60 @@ The downside of this is that apisnoop developers should be doing it from within 
    #+NAME: config.js
    #+BEGIN_SRC js
      import { createSelector } from 'redux-bundler'
+     import { trimEnd } from 'lodash'
+
+     const STORAGE_PROVIDER = 'https://storage.googleapis.com/'
+
      const config = {
-       bucket: document.querySelector('meta[name="gs-bucket"]').getAttribute('content'),
-       provider: 'https://storage.googleapis.com/'
+       provider: STORAGE_PROVIDER
      }
 
      export default {
        name: 'config',
        reducer: (state = config) => state,
        selectConfig: (state) => state.config,
+       selectConfigTwo: (state) => state.configResource.data,
+       selectProvider: (state) => state.config.provider,
+       selectGsBucket: createSelector(
+         'selectProvider',
+         'selectConfigTwo',
+         (provider, config) => {
+           let gsBucket;
+           if  (config == null || config['gs-bucket'] === undefined) return gsBucket;
+           gsBucket = config['gs-bucket']
+           return trimEnd(gsBucket, '/')
+         }
+       ),
+       selectDefaultBucketJob: createSelector(
+         'selectConfigTwo',
+         'selectGsBucket',
+         (config, gsBucket) => {
+           let defaultBucketJob, bucket, job = '';
+
+           if (config == null || config['default-view'] === undefined) return '';
+
+           bucket = trimEnd(config['default-view'].bucket, '/')
+           job = trimEnd(config['default-view'].job, '/')
+           return [gsBucket, bucket, job].join('/')
+         }
+       ),
        selectGsPath: createSelector(
+         'selectProvider',
          'selectQueryObject',
-         'selectConfig',
-         (query, config) => {
+         'selectDefaultBucketJob',
+         (provider, query, bucketJob) => {
            if (query && query.bucket) {
-             return config.provider.concat(query.bucket)
+             return provider.concat(query.bucket)
            }
-           return config.provider.concat(config.bucket)
+           return provider.concat(bucketJob)
          }
        )
      }
    #+END_SRC
+
+**
+
+** BucketList
 ** Endpoints
   :PROPERTIES:
     :header-args: :tangle ./src/bundles/endpoints.js :noweb yes
@@ -3615,6 +3686,25 @@ The downside of this is that apisnoop developers should be doing it from within 
     depth: "endpoint"
   }
 #+END_EXAMPLE
+** AuditSources (<<<◊AuditSources>>>)
+  AuditSources is a yaml file, named audit-sources.yaml, that is located at the top level of the apisnoop repo.  It determines which buckets we should generate apisnoop data for, and where it should be stored.   This allows other people to put in their own data and make apisnoop more dynamic
+  #+NAME: AuditSources Definition Example
+  #+BEGIN_SRC yaml
+      storage-provider: String
+      buckets:
+        - name: String
+          jobs:
+          - Integer
+        - name: String
+          futureX: (some value that could be added later)
+          jobs:
+          - Integer
+          - Integer
+      default-view: // which bucket job gets loaded on page load, before anything is selected
+        bucket: Bucket.name
+        job: Bucket.job
+  #+END_SRC
+
 * Glossary
 ** Bundle (<<<bundles>>> | <<<bundle>>>)
    a collection of redux code all organized by some concern or idea.  It's a marked difference from the typical organizing style, where you organize files by what they are (reducers, selectors, etc.).  This, instead, organizes files by their topic.
@@ -3971,14 +4061,47 @@ Is there a simpler way for this?  it's a filter, then a prune essentially....If 
    it's being calculated again everytime the query updates.  And we are having to calculate it for the entire tree every time.
    Perhaps we sest the color first on general "colored or not", then in sunburst we determine "faded or not"?  This would remove 1 or 2 if statements from beiong calcualted each time...i think?
 ** IDEA Refactor TestedStats for Recursion and proper FP
-** TODO  [0/4] Create initial page that lists possible buckets to check out
-   upon visiting the site, you can see a list of buckets we've run apisnoop on.  Clicking on oned brings you to the MainPage, with the sunburst and all that, with the bucket put in as the bucket query param.
-*** IDEA Initial Logic of "if query.bucket show mainpage, otherwise show ChoicePage"
-*** TODO WRite out Choice Page with List of Buckets to hit.  When clicked, they update the bucket query.
-*** TODO Verify that the data is showing from the correct bucket
-*** TODO Adjust our Metadata bundle to not be hardcoded.
+** TODO  [2/5] Load buckets and jobs dynamically from yaml file
+  [[https://github.com/cncf/apisnoop/issues/193][Github Issue #193]]: given an audit-sources.yaml, determine which buckets and jobs should be loaded into the app for visualization.
+*** DONE Define what audit-sources.yaml should look like
+    CLOSED: [2019-04-29 Mon 09:58]
+    See ◊AuditSources
+*** DONE Create audit-sources.yaml for our existing data (based on sources. yaml
+    CLOSED: [2019-04-29 Mon 10:05]
 
 
+*** BLOCKED symlink audit-sources.yaml to app/public/audit-sources.yaml
+    #+NAME: symlink audit-sources.yaml
+    #+BEGIN_SRC shell :dir ../ :results output raw
+   ln -s audit-sources.yaml app/public/audit-sources.yaml
+   tree app/public
+    #+END_SRC
+
+    #+RESULTS: symlink audit-sources.yaml
+    app/public
+    ├── assets
+    │   ├── apisnoop_logo_v1.png
+    │   ├── cncf.png
+    │   ├── loading_icon.gif
+    │   ├── logo.gif
+    │   └── packet.png
+    ├── audit-sources.yaml -> audit-sources.yaml
+    ├── favicon.ico
+    ├── index.html
+    └── stylesheet.css
+
+    1 directory, 9 files
+    apisnoop/public [error opening dir]
+
+    0 directories, 0 files
+
+    I had an issue with the symlink and wondering if it is even necessary.  This whole thing works if we have an audit-sources.yaml in our public folder...but this presumes that we did the parsing of the audit-sources.yaml in data-gen....so what if we don't include an audit-sources.yaml by default, and make the copying of it part of our data-gen work?  So whedn data-gen is finished, it copies audit-sources.yaml into app/public, and that's how we know it's ready.  we could even include a check in our build script that says "if there is not this file available stop build and send back response of 'you need to process data first'"
+*** IN-PROGRESS pull in and parse this yaml file within our 'configResource' bundle
+*** TODO Default Bucket chosen for initial view
+   I figure th is should just be the first bucket in the list...nah, cos the buckets will be an objcet not a list.  we could have a setting called default: true.
+*** TODO Bring up GoogleStorage requirement.  do i understand it right, that we do require this?
+*** TODO Need for CORS talk and maybe error message for if a CORS issue comes up?
+    if peopleare uploading to their own buckets, they also need to add us as a reader of tha tsame bucket.
 
 * Finished Tasks
 ** DONE Port over Useragents Bundle

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -2932,11 +2932,13 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -2949,15 +2951,18 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -3060,7 +3065,8 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -3070,6 +3076,7 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -3082,17 +3089,20 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
               "version": "0.0.8",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -3109,6 +3119,7 @@
             "mkdirp": {
               "version": "0.5.1",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -3181,7 +3192,8 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -3191,6 +3203,7 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -3296,6 +3309,7 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -13261,6 +13275,7 @@
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -13273,7 +13288,8 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
@@ -13385,7 +13401,8 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -13395,6 +13412,7 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -13407,6 +13425,7 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -13506,7 +13525,8 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -13621,6 +13641,7 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",

--- a/app/package.json
+++ b/app/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "dayjs": "^1.8.12",
     "internal-nav-helper": "^1.2.0",
+    "js-yaml": "^3.13.1",
     "lodash": "^4.17.11",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",

--- a/app/public/audit-sources.yaml
+++ b/app/public/audit-sources.yaml
@@ -1,0 +1,20 @@
+gs-bucket: apisnoop/default
+buckets:
+  ci-kubernetes-e2e-gce-cos-k8sstable3-default:
+    jobs:
+      - '1121083339638312961'
+  ci-kubernetes-e2e-gce-cos-k8sstable2-default:
+    jobs:
+      - '1121457989778149377'
+  ci-kubernetes-e2e-gce-cos-k8sstable1-default:
+    jobs:
+      - '1121581392354873344'
+  ci-kubernetes-e2e-gce-cos-k8sbeta-default:
+    jobs:
+      - '1121564030004105216'
+  ci-kubernetes-e2e-gci-gce:
+    jobs:
+      - '1121334929389522946'
+default-view:
+  bucket: ci-kubernetes-e2e-gci-gce
+  job: '1121334929389522946'

--- a/app/src/bundles/bucket-list.js
+++ b/app/src/bundles/bucket-list.js
@@ -1,0 +1,31 @@
+import { createSelector } from 'redux-bundler'
+import { flatten, map } from 'lodash'
+
+export default {
+  name: 'bucketList',
+  selectBuckets: createSelector(
+    'selectConfig',
+    (config) => {
+      let buckets = {};
+      if (!config || !config.buckets) return buckets
+      buckets = config.buckets
+      return buckets
+    }
+  )
+  ,
+  selectBucketJobPaths: createSelector(
+    'selectGsBucket',
+    'selectBuckets',
+    (gsBucket, buckets) => {
+      let bucketJobPaths = [];
+      if (!gsBucket || !buckets) return bucketJobPaths
+      bucketJobPaths = map(buckets, (value, key) => {
+        let bucket = key;
+        let paths = [];
+        value['jobs'].forEach(job => paths.push([gsBucket, bucket, job].join('/')))
+        return paths
+      })
+      return flatten(bucketJobPaths)
+    }
+  )
+}

--- a/app/src/bundles/config-resource.js
+++ b/app/src/bundles/config-resource.js
@@ -1,0 +1,19 @@
+import { createAsyncResourceBundle, createSelector } from 'redux-bundler'
+import * as yaml from 'yaml'
+
+const bundle = createAsyncResourceBundle({
+  name: 'configResource',
+  getPromise: () => {
+    return fetch('audit-sources.yaml').then(response => response.text()).then(text => yaml.parse(text, 'utf8'))
+  }
+})
+
+bundle.reactConfigResourceFetch = createSelector(
+  'selectConfigResourceShouldUpdate',
+  (shouldUpdate) => {
+    if (!shouldUpdate) return
+    return { actionCreator: 'doFetchConfigResource' }
+  }
+)
+
+export default bundle

--- a/app/src/bundles/config-resource.js
+++ b/app/src/bundles/config-resource.js
@@ -1,10 +1,10 @@
 import { createAsyncResourceBundle, createSelector } from 'redux-bundler'
-import * as yaml from 'yaml'
+import * as yaml from 'js-yaml'
 
 const bundle = createAsyncResourceBundle({
   name: 'configResource',
   getPromise: () => {
-    return fetch('audit-sources.yaml').then(response => response.text()).then(text => yaml.parse(text, 'utf8'))
+    return fetch('audit-sources.yaml').then(response => response.text()).then(text => yaml.safeLoad(text, 'utf8'))
   }
 })
 

--- a/app/src/bundles/config.js
+++ b/app/src/bundles/config.js
@@ -10,12 +10,12 @@ const config = {
 export default {
   name: 'config',
   reducer: (state = config) => state,
-  selectConfig: (state) => state.config,
-  selectConfigTwo: (state) => state.configResource.data,
+  selectConfigDUMP: (state) => state.config,
+  selectConfig: (state) => state.configResource.data,
   selectProvider: (state) => state.config.provider,
   selectGsBucket: createSelector(
     'selectProvider',
-    'selectConfigTwo',
+    'selectConfig',
     (provider, config) => {
       let gsBucket;
       if  (config == null || config['gs-bucket'] === undefined) return gsBucket;
@@ -24,7 +24,7 @@ export default {
     }
   ),
   selectDefaultBucketJob: createSelector(
-    'selectConfigTwo',
+    'selectConfig',
     'selectGsBucket',
     (config, gsBucket) => {
       let defaultBucketJob, bucket, job = '';

--- a/app/src/bundles/index.js
+++ b/app/src/bundles/index.js
@@ -3,6 +3,7 @@ import { composeBundles } from 'redux-bundler'
 import activeLocation from './active-location'
 import colours from './colours'
 import config from './config'
+import configResource from './config-resource'
 import endpoints from './endpoints'
 import endpointsResource from './endpoints-resource'
 import metadataResource from './metadata-resource'
@@ -23,6 +24,7 @@ export default composeBundles(
   activeLocation,
   colours,
   config,
+  configResource,
   endpoints,
   endpointsResource,
   metadataResource,

--- a/app/src/bundles/index.js
+++ b/app/src/bundles/index.js
@@ -1,6 +1,7 @@
 import { composeBundles } from 'redux-bundler'
 
 import activeLocation from './active-location'
+import bucketList from './bucket-list'
 import colours from './colours'
 import config from './config'
 import configResource from './config-resource'
@@ -22,6 +23,7 @@ import zoom from './zoom'
 
 export default composeBundles(
   activeLocation,
+  bucketList,
   colours,
   config,
   configResource,

--- a/app/src/bundles/metadata.js
+++ b/app/src/bundles/metadata.js
@@ -12,7 +12,7 @@ export default {
    }
   ),
   selectBucket: createSelector(
-    'selectConfig',
+    'selectConfigDUMP',
     'selectQueryObject',
     (config, query) => {
       let bucket = ''

--- a/app/src/components/bucket-list.js
+++ b/app/src/components/bucket-list.js
@@ -18,13 +18,14 @@ function BucketList (props) {
           doMarkTestSequencesResourceAsOutdated,
           doMarkTestTagsResourceAsOutdated,
           doMarkUseragentsResourceAsOutdated,
+          bucketJobPaths,
           bucket
         } = props
   return (
       <div id='bucket-list'>
       <h2>Select a Bucket</h2>
       <ul className="list flex flex-wrap pl0">
-      {buckets.map((b, i) => {
+      {bucketJobPaths.map((b, i) => {
         return (
             <li className='pr2 pb2' key={`bucket_${i}`}>
             {(b === bucket) &&
@@ -39,16 +40,14 @@ function BucketList (props) {
   )
 
   function handleClick (e) {
-    let storagePath = 'apisnoop/default/'
-    let bucket = e.target.innerHTML
-    let fullPath = storagePath.concat(bucket)
+    let bucket = e.target.textContent
     doMarkEndpointsResourceAsOutdated()
     doMarkTestsResourceAsOutdated()
     doMarkTestSequencesResourceAsOutdated()
     doMarkTestTagsResourceAsOutdated()
     doMarkMetadataResourceAsOutdated()
     doMarkUseragentsResourceAsOutdated()
-    doUpdateQuery({bucket: fullPath})
+    doUpdateQuery({bucket: bucket})
   }
 }
 
@@ -61,5 +60,6 @@ export default connect(
   'doMarkTestTagsResourceAsOutdated',
   'doMarkUseragentsResourceAsOutdated',
   'selectBucket',
+  'selectBucketJobPaths',
   BucketList
 )


### PR DESCRIPTION
We now generate our paths and visualizations from an audit-sources.yaml file, which is located in app/public/

This can be edited and set to pull from different bucket/jobs or from different GCS prefixes.