### PR TITLE
toggle sunburst to untested, tested, and/or conformance-tested only

### DIFF
--- a/app/app.org
+++ b/app/app.org
@@ -750,6 +750,7 @@ The downside of this is that apisnoop developers should be doing it from within 
       import {
         groupBy,
         isEmpty,
+        toString,
         mapValues,
         pickBy } from 'lodash'
 
@@ -790,8 +791,9 @@ The downside of this is that apisnoop developers should be doing it from within 
          'selectOpIdsHitByFilteredUseragents',
          'selectOpIdsHitByFilteredTestTags',
          'selectOpIdsHitByFilteredTests',
+         'selectQueryObject',
          'selectZoom',
-         (endpoints, useragentOpIds, testTagOpIds, testsOpIds, zoom) => {
+         (endpoints, useragentOpIds, testTagOpIds, testsOpIds, query, zoom) => {
            if (endpoints == null) return null
            if (Array.isArray(useragentOpIds) && useragentOpIds.length > 0) {
              endpoints = filterBy(useragentOpIds, endpoints)
@@ -801,6 +803,26 @@ The downside of this is that apisnoop developers should be doing it from within 
            }
            if (Array.isArray(testsOpIds) && testsOpIds.length > 0) {
              endpoints = filterBy(testsOpIds, endpoints)
+           }
+           if (query.showUntested && query.showUntested === 'false') {
+             endpoints = pickBy(endpoints, (val, key) => {
+               return (val.testHits > 0)
+             })
+           }
+           if (query.showConformanceTested && query.showConformanceTested === 'false') {
+             endpoints = pickBy(endpoints, (val, key) => {
+               return (val.conformanceHits === 0)
+             })
+           }
+           if (query.showTested && query.showTested === 'false' && query.showConformanceTested === 'true') {
+             endpoints = pickBy(endpoints, (val, key) => {
+               return (val.testHits === 0 || val.conformanceHits > 0)
+             })
+           }
+           if (query.showTested && query.showTested === 'false' && query.showConformanceTested === 'false') {
+             endpoints = pickBy(endpoints, (val, key) => {
+               return (val.testHits === 0)
+             })
            }
            if (!isEmpty(zoom) && (zoom.depth === 'operationId' || zoom.depth === 'category')) {
              endpoints = pickBy(endpoints, (val, key) => val.level === zoom.level && val.category === zoom.category)
@@ -2824,12 +2846,14 @@ The downside of this is that apisnoop developers should be doing it from within 
 
      import Sunburst from './sunburst'
      import SunburstHeader from './sunburst-header'
+     import TestedToggle from './tested-toggle'
 
      const SunburstContainer = (props) => {
        return (
            <div id='sunburst-container' className='flex flex-column mr4'>
            <SunburstHeader />
            <Sunburst />
+           <TestedToggle />
            </div>
        )
      }
@@ -2974,6 +2998,66 @@ The downside of this is that apisnoop developers should be doing it from within 
         SunburstChart
       )
     #+END_SRC
+** Tested Toggle
+    :PROPERTIES:
+    :header-args: :tangle ./src/components/tested-toggle.js
+    :END:
+   This is a component to go beneath the sunburst, that determines whether we show untested, tested, and/or conformance-tested endpoints.
+   #+NAME: Tested Toggle
+   #+BEGIN_SRC js
+     import React, { useState } from 'react'
+     import { connect } from 'redux-bundler-react'
+     import { toString } from 'lodash'
+
+     const TestedToggle = (props) => {
+       const {
+         queryObject,
+         doUpdateQuery
+       } = props
+
+       let untestedIsChecked = !queryObject.showUntested || queryObject.showUntested === 'true'
+       let testedIsChecked = !queryObject.showTested || queryObject.showTested === 'true'
+       let conformanceTestedIsChecked = !queryObject.showConformanceTested || queryObject.showConformanceTested === 'true'
+
+       return (
+         <fieldset>
+           <legend>Visible Endpoints</legend>
+           <div>
+           <input type='checkbox' name='showUntested' id='untested' onInput={handleChange} checked={untestedIsChecked}/>
+             <label for='untested'>untested</label>
+           <input type='checkbox' name='showTested' id='tested' onInput={handleChange} checked={testedIsChecked} />
+             <label for='untested'>tested</label>
+           <input type='checkbox' name='showConformanceTested' id='conformanceTested' onInput={handleChange} checked={conformanceTestedIsChecked} />
+             <label for='untested'>conformance-tested</label>
+           </div>
+         </fieldset>
+       )
+
+       function handleChange (e) {
+         e.preventDefault()
+         let name = e.target.name
+         e.target.checked = !e.target.checked
+         let isChecked = e.target.checked
+         let query = queryObject
+         query.showUntested = untestedIsChecked
+         query.showTested = testedIsChecked
+         query.showConformanceTested = conformanceTestedIsChecked
+         query[name] = isChecked
+         doUpdateQuery({ ...query })
+       }
+
+       function isTrue (string) {
+         return string === 'true'
+       }
+     }
+
+     export default connect(
+       'doUpdateQuery',
+       'selectQueryObject',
+       TestedToggle
+     )
+   #+END_SRC
+
 ** Summary Container
    :PROPERTIES:
    :header-args: :tangle ./src/components/summary-container.js

--- a/app/app.org
+++ b/app/app.org
@@ -750,7 +750,6 @@ The downside of this is that apisnoop developers should be doing it from within 
       import {
         groupBy,
         isEmpty,
-        toString,
         mapValues,
         pickBy } from 'lodash'
 
@@ -3005,9 +3004,8 @@ The downside of this is that apisnoop developers should be doing it from within 
    This is a component to go beneath the sunburst, that determines whether we show untested, tested, and/or conformance-tested endpoints.
    #+NAME: Tested Toggle
    #+BEGIN_SRC js
-     import React, { useState } from 'react'
+     import React from 'react'
      import { connect } from 'redux-bundler-react'
-     import { toString } from 'lodash'
 
      const TestedToggle = (props) => {
        const {
@@ -3020,15 +3018,15 @@ The downside of this is that apisnoop developers should be doing it from within 
        let conformanceTestedIsChecked = !queryObject.showConformanceTested || queryObject.showConformanceTested === 'true'
 
        return (
-         <fieldset>
+         <fieldset className='flex flex-row flex-wrap'>
            <legend>Visible Endpoints</legend>
-           <div>
+           <div className=''>
            <input type='checkbox' name='showUntested' id='untested' onInput={handleChange} checked={untestedIsChecked}/>
-             <label for='untested'>untested</label>
+             <label for='untested' className='mr2'>untested</label>
            <input type='checkbox' name='showTested' id='tested' onInput={handleChange} checked={testedIsChecked} />
-             <label for='untested'>tested</label>
+             <label for='untested' className='mr2'>tested</label>
            <input type='checkbox' name='showConformanceTested' id='conformanceTested' onInput={handleChange} checked={conformanceTestedIsChecked} />
-             <label for='untested'>conformance-tested</label>
+             <label for='untested' className='mr2'>conformance-tested</label>
            </div>
          </fieldset>
        )
@@ -3038,16 +3036,14 @@ The downside of this is that apisnoop developers should be doing it from within 
          let name = e.target.name
          e.target.checked = !e.target.checked
          let isChecked = e.target.checked
-         let query = queryObject
-         query.showUntested = untestedIsChecked
-         query.showTested = testedIsChecked
-         query.showConformanceTested = conformanceTestedIsChecked
+         let query = {
+           ...queryObject,
+           showUntested: untestedIsChecked,
+           showTested: testedIsChecked,
+           showConformanceTested: conformanceTestedIsChecked
+         }
          query[name] = isChecked
          doUpdateQuery({ ...query })
-       }
-
-       function isTrue (string) {
-         return string === 'true'
        }
      }
 

--- a/app/src/bundles/endpoints.js
+++ b/app/src/bundles/endpoints.js
@@ -2,6 +2,7 @@ import { createSelector } from 'redux-bundler'
 import {
   groupBy,
   isEmpty,
+  toString,
   mapValues,
   pickBy } from 'lodash'
 
@@ -41,8 +42,9 @@ export default {
     'selectOpIdsHitByFilteredUseragents',
     'selectOpIdsHitByFilteredTestTags',
     'selectOpIdsHitByFilteredTests',
+    'selectQueryObject',
     'selectZoom',
-    (endpoints, useragentOpIds, testTagOpIds, testsOpIds, zoom) => {
+    (endpoints, useragentOpIds, testTagOpIds, testsOpIds, query, zoom) => {
       if (endpoints == null) return null
       if (Array.isArray(useragentOpIds) && useragentOpIds.length > 0) {
         endpoints = filterBy(useragentOpIds, endpoints)
@@ -52,6 +54,26 @@ export default {
       }
       if (Array.isArray(testsOpIds) && testsOpIds.length > 0) {
         endpoints = filterBy(testsOpIds, endpoints)
+      }
+      if (query.showUntested && query.showUntested === 'false') {
+        endpoints = pickBy(endpoints, (val, key) => {
+          return (val.testHits > 0)
+        })
+      }
+      if (query.showConformanceTested && query.showConformanceTested === 'false') {
+        endpoints = pickBy(endpoints, (val, key) => {
+          return (val.conformanceHits === 0)
+        })
+      }
+      if (query.showTested && query.showTested === 'false' && query.showConformanceTested === 'true') {
+        endpoints = pickBy(endpoints, (val, key) => {
+          return (val.testHits === 0 || val.conformanceHits > 0)
+        })
+      }
+      if (query.showTested && query.showTested === 'false' && query.showConformanceTested === 'false') {
+        endpoints = pickBy(endpoints, (val, key) => {
+          return (val.testHits === 0)
+        })
       }
       if (!isEmpty(zoom) && (zoom.depth === 'operationId' || zoom.depth === 'category')) {
         endpoints = pickBy(endpoints, (val, key) => val.level === zoom.level && val.category === zoom.category)
@@ -84,6 +106,7 @@ export default {
 
 // opIds, endpoints => endpoints
 // if endpoint.opId is in the array of opIds keep it.
+
 function filterBy (filteredOpIds, opIds) {
  return pickBy(opIds, (val, key) => {
     return filteredOpIds.includes(val.operationId)

--- a/app/src/bundles/endpoints.js
+++ b/app/src/bundles/endpoints.js
@@ -2,7 +2,6 @@ import { createSelector } from 'redux-bundler'
 import {
   groupBy,
   isEmpty,
-  toString,
   mapValues,
   pickBy } from 'lodash'
 

--- a/app/src/components/sunburst-container.js
+++ b/app/src/components/sunburst-container.js
@@ -3,12 +3,14 @@ import { connect } from 'redux-bundler-react'
 
 import Sunburst from './sunburst'
 import SunburstHeader from './sunburst-header'
+import TestedToggle from './tested-toggle'
 
 const SunburstContainer = (props) => {
   return (
       <div id='sunburst-container' className='flex flex-column mr4'>
       <SunburstHeader />
       <Sunburst />
+      <TestedToggle />
       </div>
   )
 }

--- a/app/src/components/tested-toggle.js
+++ b/app/src/components/tested-toggle.js
@@ -1,0 +1,51 @@
+import React, { useState } from 'react'
+import { connect } from 'redux-bundler-react'
+import { toString } from 'lodash'
+
+const TestedToggle = (props) => {
+  const {
+    queryObject,
+    doUpdateQuery
+  } = props
+
+  let untestedIsChecked = !queryObject.showUntested || queryObject.showUntested === 'true'
+  let testedIsChecked = !queryObject.showTested || queryObject.showTested === 'true'
+  let conformanceTestedIsChecked = !queryObject.showConformanceTested || queryObject.showConformanceTested === 'true'
+
+  return (
+    <fieldset>
+      <legend>Visible Endpoints</legend>
+      <div>
+      <input type='checkbox' name='showUntested' id='untested' onInput={handleChange} checked={untestedIsChecked}/>
+        <label for='untested'>untested</label>
+      <input type='checkbox' name='showTested' id='tested' onInput={handleChange} checked={testedIsChecked} />
+        <label for='untested'>tested</label>
+      <input type='checkbox' name='showConformanceTested' id='conformanceTested' onInput={handleChange} checked={conformanceTestedIsChecked} />
+        <label for='untested'>conformance-tested</label>
+      </div>
+    </fieldset>
+  )
+
+  function handleChange (e) {
+    e.preventDefault()
+    let name = e.target.name
+    e.target.checked = !e.target.checked
+    let isChecked = e.target.checked
+    let query = queryObject
+    query.showUntested = untestedIsChecked
+    query.showTested = testedIsChecked
+    query.showConformanceTested = conformanceTestedIsChecked
+    query[name] = isChecked
+    doUpdateQuery({ ...query })
+  }
+
+  function isTrue (string) {
+    return string === 'true'
+  }
+}
+
+export default connect(
+  'doUpdateQuery',
+  'selectQueryObject',
+  TestedToggle
+)

--- a/app/src/components/tested-toggle.js
+++ b/app/src/components/tested-toggle.js
@@ -1,6 +1,5 @@
-import React, { useState } from 'react'
+import React from 'react'
 import { connect } from 'redux-bundler-react'
-import { toString } from 'lodash'
 
 const TestedToggle = (props) => {
   const {
@@ -13,15 +12,15 @@ const TestedToggle = (props) => {
   let conformanceTestedIsChecked = !queryObject.showConformanceTested || queryObject.showConformanceTested === 'true'
 
   return (
-    <fieldset>
+    <fieldset className='flex flex-row flex-wrap'>
       <legend>Visible Endpoints</legend>
-      <div>
+      <div className=''>
       <input type='checkbox' name='showUntested' id='untested' onInput={handleChange} checked={untestedIsChecked}/>
-        <label for='untested'>untested</label>
+        <label for='untested' className='mr2'>untested</label>
       <input type='checkbox' name='showTested' id='tested' onInput={handleChange} checked={testedIsChecked} />
-        <label for='untested'>tested</label>
+        <label for='untested' className='mr2'>tested</label>
       <input type='checkbox' name='showConformanceTested' id='conformanceTested' onInput={handleChange} checked={conformanceTestedIsChecked} />
-        <label for='untested'>conformance-tested</label>
+        <label for='untested' className='mr2'>conformance-tested</label>
       </div>
     </fieldset>
   )
@@ -31,16 +30,14 @@ const TestedToggle = (props) => {
     let name = e.target.name
     e.target.checked = !e.target.checked
     let isChecked = e.target.checked
-    let query = queryObject
-    query.showUntested = untestedIsChecked
-    query.showTested = testedIsChecked
-    query.showConformanceTested = conformanceTestedIsChecked
+    let query = {
+      ...queryObject,
+      showUntested: untestedIsChecked,
+      showTested: testedIsChecked,
+      showConformanceTested: conformanceTestedIsChecked
+    }
     query[name] = isChecked
     doUpdateQuery({ ...query })
-  }
-
-  function isTrue (string) {
-    return string === 'true'
   }
 }
 


### PR DESCRIPTION
This implements a visible endpoint toggle, implementing #244 .  

The code is blunt, but workable.  Working through our endpoints bundle so its filtering is smaller, and more elegant, would be useful future work. 