### PR TITLE
Support processing proxy endpoints

### DIFF
--- a/apps/hasura/migrations/111_function_load_audit_event.up.sql
+++ b/apps/hasura/migrations/111_function_load_audit_event.up.sql
@@ -104,7 +104,14 @@ def find_operation_id(openapi_spec, event):
       return openapi_spec['hit_cache'][url.path][method]
   uri_parts = url.path.strip('/').split('/')
   if 'proxy' in uri_parts:
-      uri_parts = uri_parts[0:uri_parts.index('proxy')]
+      # All parts up to proxy
+      z=uri_parts[0:uri_parts.index('proxy')]
+      # proxy is a single part of the uri_parts
+      z.append('proxy')
+      # However all parameters after that are another single argument
+      # to the proxy
+      z.append('/'.join(uri_parts[uri_parts.index('proxy')+1:]))
+      uri_parts = z
   part_count = len(uri_parts)
   try: # may have more parts... so no match
       cache = openapi_spec['cache'][part_count]
@@ -160,7 +167,11 @@ def find_operation_id(openapi_spec, event):
         else:
           print(url.path)
           return None
-      next_level={v: k for k, v in variable_levels.items()}[True]
+      try: # may have more parts... so no match # variable_levels -> {'{namespace}': False}
+        next_level={v: k for k, v in variable_levels.items()}[True]
+      except Exception as e: # TODO better to not use try/except
+        next_level=[*variable_levels][0]
+      # import ipdb; ipdb.set_trace()
       current_level = current_level[next_level] #coo
   try:
     op_id=current_level[method]

--- a/apps/hasura/migrations/112_function_add_opp_id.up.sql
+++ b/apps/hasura/migrations/112_function_add_opp_id.up.sql
@@ -103,7 +103,14 @@ def find_operation_id(openapi_spec, event):
       return openapi_spec['hit_cache'][url.path][method]
   uri_parts = url.path.strip('/').split('/')
   if 'proxy' in uri_parts:
-      uri_parts = uri_parts[0:uri_parts.index('proxy')]
+      # All parts up to proxy
+      z=uri_parts[0:uri_parts.index('proxy')]
+      # proxy is a single part of the uri_parts
+      z.append('proxy')
+      # However all parameters after that are another single argument
+      # to the proxy
+      z.append('/'.join(uri_parts[uri_parts.index('proxy')+1:]))
+      uri_parts = z
   part_count = len(uri_parts)
   try: # may have more parts... so no match
       cache = openapi_spec['cache'][part_count]
@@ -159,7 +166,11 @@ def find_operation_id(openapi_spec, event):
         else:
           print(url.path)
           return None
-      next_level={v: k for k, v in variable_levels.items()}[True]
+      try: # may have more parts... so no match # variable_levels -> {'{namespace}': False}
+        next_level={v: k for k, v in variable_levels.items()}[True]
+      except Exception as e: # TODO better to not use try/except
+        next_level=[*variable_levels][0]
+      # import ipdb; ipdb.set_trace()
       current_level = current_level[next_level] #coo
   try:
     op_id=current_level[method]

--- a/kustomize/kustomization.yaml
+++ b/kustomize/kustomization.yaml
@@ -1,13 +1,13 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 bases:
-  - ../delpoyment/k8s/nginx-ingress
-  - ../delpoyment/k8s/postgres
-  - ../delpoyment/k8s/hasura
-  - ../delpoyment/k8s/pgadmin
-  - ../delpoyment/k8s/auditlogger
-  - ../delpoyment/k8s/webapp
-  - ../delpoyment/k8s/tilt
+  - ../deployment/k8s/nginx-ingress
+  - ../deployment/k8s/postgres
+  - ../deployment/k8s/hasura
+  - ../deployment/k8s/pgadmin
+  - ../deployment/k8s/auditlogger
+  - ../deployment/k8s/webapp
+  - ../deployment/k8s/tilt
 patchesJson6902:
   - target:
       group: extensions

--- a/org/tables_and_views_bot.org
+++ b/org/tables_and_views_bot.org
@@ -280,7 +280,14 @@ CREATE INDEX idx_audit_event_jsonb_path_jobs  ON raw_audit_event USING GIN (data
         return openapi_spec['hit_cache'][url.path][method]
     uri_parts = url.path.strip('/').split('/')
     if 'proxy' in uri_parts:
-        uri_parts = uri_parts[0:uri_parts.index('proxy')]
+        # All parts up to proxy
+        z=uri_parts[0:uri_parts.index('proxy')]
+        # proxy is a single part of the uri_parts
+        z.append('proxy')
+        # However all parameters after that are another single argument
+        # to the proxy
+        z.append('/'.join(uri_parts[uri_parts.index('proxy')+1:]))
+        uri_parts = z
     part_count = len(uri_parts)
     try: # may have more parts... so no match
         cache = openapi_spec['cache'][part_count]
@@ -336,7 +343,11 @@ CREATE INDEX idx_audit_event_jsonb_path_jobs  ON raw_audit_event USING GIN (data
           else:
             print(url.path)
             return None
-        next_level={v: k for k, v in variable_levels.items()}[True]
+        try: # may have more parts... so no match # variable_levels -> {'{namespace}': False}
+          next_level={v: k for k, v in variable_levels.items()}[True]
+        except Exception as e: # TODO better to not use try/except
+          next_level=[*variable_levels][0]
+        # import ipdb; ipdb.set_trace()
         current_level = current_level[next_level] #coo
     try:
       op_id=current_level[method]


### PR DESCRIPTION
When looking back at our older data (1.15 timeframe) I noted that we have proxy endpoints that were being treated differently. In most cases being treated as the epndoint they were a proxy for.
This updates the way we process proxy endpoints to be more closely related to our standard endpoints.