### PR TITLE
fix bizarre graph behaviour when filtering to conformance only on home page

### DIFF
--- a/apps/web/src/components/Sunburst/ConformanceToggle.svelte
+++ b/apps/web/src/components/Sunburst/ConformanceToggle.svelte
@@ -7,6 +7,7 @@
      window.location.search.toLowerCase().includes("conformance-only=true");
 
  function toggleConformanceFilter ({target}) {
+     console.log({target})
      const path = window.location.pathname;
      if (target.checked) {
          page(`${path}?conformance-only=true`);

--- a/apps/web/src/store/index.js
+++ b/apps/web/src/store/index.js
@@ -45,13 +45,12 @@ export const versions = derived(releases, ($releases, set) => {
 });
 
 export const latestVersion = derived(
-  releases,
-  ($releases, set) => {
-    if ($releases && !isEmpty($releases)) {
-      const latest = last(sortBy($releases, 'release_date'));
-      set(latest.release);
+  versions,
+  ($v, set) => {
+    if (!isEmpty($v)) {
+      set($v[0]);
     } else {
-      set('')
+      set('');
     }
   }
 );
@@ -64,7 +63,7 @@ export const activeFilters = writable({
   category: '',
   endpoint: '',
   version: '',
-  conformanceOnly: true
+  conformanceOnly: false
 });
 
 export const activeRelease = derived(


### PR DESCRIPTION
issue was with how we calculated the latest version.  

Before, it was based on releases, with an implied sorting happening that
was not as consistent as we imagined.  This caused unexpected behaviour on the homepage, as clicking the conformance filter would cause the latest version to switch, which caused a refresh in data.  

 Now we base it off an already sorted list of release versions.  We could likely simplify this even further, to have even less moving parts, if that is desired.