### PR TITLE
Correctly track all proxy endpoints

### DIFF
--- a/apps/snoopdb/postgres/snoopUtils.py
+++ b/apps/snoopdb/postgres/snoopUtils.py
@@ -211,8 +211,9 @@ def load_openapi_spec(url):
 def format_uri_parts_for_proxy(uri_parts):
     formatted_parts=uri_parts[0:uri_parts.index('proxy')]
     formatted_parts.append('proxy')
-    formatted_parts.append('/'.join(
-        uri_parts[uri_parts.index('proxy')+1:]))
+    proxy_tail = uri_parts[uri_parts.index('proxy')+1:]
+    if len(proxy_tail):
+        formatted_parts.append('/'.join(proxy_tail))
     return formatted_parts
 
 def find_operation_id(openapi_spec, event):


### PR DESCRIPTION
The function `format_uri_parts_for_proxy` would always add a trailing item to the uri parts list. This would be a null item when it was a root endpoint which would then be incorrectly reported by apisnoop as a `ProxyWithPath` endpoint.

```
Event: {'user': {'groups': ['system:masters', 'system:authenticated'], 'username': 'kubernetes-admin'}, 'verb': 'delete', 'level': 'Metadata', 'stage': 'RequestReceived', 'auditID': 'c333390b-e52c-4e88-b42c-95acd0efba59',
 'objectRef': {'name': 'debug-proxy', 'resource': 'pods', 'namespace': 'default', 'apiVersion': 'v1', 'subresource': 'proxy'}, 'sourceIPs': ['127.0.0.1', '172.18.0.1'], 'userAgent': 'curl/7.68.0',
 'requestURI': '/api/v1/namespaces/default/pods/debug-proxy/proxy/some/path?resource=345', 'stageTimestamp': '2021-08-16T20:04:57.531747Z', 'requestReceivedTimestamp': '2021-08-16T20:04:57.531747Z'}
```
Is reported as `CoreV1DeleteNamespacedPodProxyWithPath`

```
Event: {'user': {'groups': ['system:masters', 'system:authenticated'], 'username': 'kubernetes-admin'}, 'verb': 'delete', 'level': 'Metadata', 'stage': 'RequestReceived', 'auditID': 'd0abee73-40cd-4ab4-9738-36c8908c2c73',
 'objectRef': {'name': 'debug-proxy', 'resource': 'pods', 'namespace': 'default', 'apiVersion': 'v1', 'subresource': 'proxy'}, 'sourceIPs': ['127.0.0.1', '172.18.0.1'], 'userAgent': 'curl/7.68.0',
 'requestURI': '/api/v1/namespaces/default/pods/debug-proxy/proxy?id=123', 'stageTimestamp': '2021-08-16T20:04:49.060704Z', 'requestReceivedTimestamp': '2021-08-16T20:04:49.060704Z'}
```
Is reported now as `connectCoreV1DeleteNamespacedPodProxy`