### PR TITLE
upgrade pip and requests

### DIFF
--- a/apps/snoopdb/postgres/Dockerfile
+++ b/apps/snoopdb/postgres/Dockerfile
@@ -6,14 +6,12 @@ RUN apt-get update \
   postgresql-plpython3-12 \
   postgresql-12-plsh \
   postgresql-server-dev-12 \
-  # python3-selenium \
   python3-pip \
   python3-bs4 \
   python3-psycopg2 \
   python3-ipdb \
   python3-requests \
   python3-yaml \
-  python3-setuptools \
   libpq-dev \
   wget \
   make \
@@ -28,10 +26,7 @@ RUN apt-get update \
 
 RUN python3 --version
 RUN pip3 install --upgrade pip
-# RUN pip3 install cffi
 RUN pip3 install --upgrade requests
-# RUN pip3 install xcffib
-# RUN pip3 install --upgrade cffi xcffib
 RUN pip3 install selenium webdriver-manager
 RUN wget "https://github.com/mozilla/geckodriver/releases/download/v0.29.1/geckodriver-v0.29.1-linux64.tar.gz" \
     && tar xvf geckodriver* \

--- a/apps/snoopdb/postgres/Dockerfile
+++ b/apps/snoopdb/postgres/Dockerfile
@@ -13,6 +13,7 @@ RUN apt-get update \
   python3-ipdb \
   python3-requests \
   python3-yaml \
+  python3-setuptools \
   libpq-dev \
   wget \
   make \
@@ -26,6 +27,11 @@ RUN apt-get update \
 
 
 RUN python3 --version
+RUN pip3 install --upgrade pip
+# RUN pip3 install cffi
+RUN pip3 install --upgrade requests
+# RUN pip3 install xcffib
+# RUN pip3 install --upgrade cffi xcffib
 RUN pip3 install selenium webdriver-manager
 RUN wget "https://github.com/mozilla/geckodriver/releases/download/v0.29.1/geckodriver-v0.29.1-linux64.tar.gz" \
     && tar xvf geckodriver* \


### PR DESCRIPTION
New images of snoopdb are failing due to dependency errors. Investigating, it looks like the installed versions of requests and pip are out of date in this image.  The dockerfile now explicitly upgrades them so that our plpython functions work correctly in our postgres db.