### PR TITLE
Add extraEnv to Helm charts

### DIFF
--- a/charts/auditlogger/templates/deployment.yaml
+++ b/charts/auditlogger/templates/deployment.yaml
@@ -51,6 +51,9 @@ spec:
               value: {{ .Values.service.port | toString | quote }}
             - name: APP_DISABLE_LOGS
               value: {{ .Values.noDebug | toString | quote }}
+          {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.service.port }}

--- a/charts/auditlogger/values.yaml
+++ b/charts/auditlogger/values.yaml
@@ -29,7 +29,8 @@ serviceAccount:
 
 podAnnotations: {}
 
-podSecurityContext: {}
+podSecurityContext:
+  {}
   # fsGroup: 2000
 
 securityContext:
@@ -49,7 +50,8 @@ service:
   port: 9900
   clusterIP: 10.96.96.96
 
-resources: {}
+resources:
+  {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
@@ -73,3 +75,5 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+extraEnv: []

--- a/charts/snoopdb/templates/statefulset.yaml
+++ b/charts/snoopdb/templates/statefulset.yaml
@@ -81,6 +81,9 @@ spec:
             - name: POSTGRES_HOST_AUTH_METHOD
               value: trust
           {{- end }}
+          {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           livenessProbe:
             exec:
               command:

--- a/charts/snoopdb/values.yaml
+++ b/charts/snoopdb/values.yaml
@@ -29,7 +29,7 @@ serviceAccount:
 
 podAnnotations: {}
 
-podSecurityContext: 
+podSecurityContext:
   fsGroup: 70
 
 securityContext:
@@ -48,7 +48,8 @@ service:
   type: ClusterIP
   port: 5432
 
-resources: {}
+resources:
+  {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
@@ -72,3 +73,5 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+extraEnv: []


### PR DESCRIPTION
Will allow for setting envs like of 
```
--set extraEnv[0].name=HIII --set extraEnv[0].value=Yoooo
```