### PR TITLE
Testing only var

### DIFF
--- a/.sharing.io/init
+++ b/.sharing.io/init
@@ -2,10 +2,18 @@
 
 export SCRIPT_PATH="$(dirname $(realpath $0))"
 
+EXTRA_ENV=""
+
+if [[ -z "${TESTING_ONLY}" ]]; then
+  EXTRA_ENV=""
+else
+  echo "TESTING!!!"
+  EXTRA_ENV="--set extraEnv[0].name=TESTING_ONLY --set extraEnv[0].value=on"
+
 if [ -f /var/run/secrets/kubernetes.io/serviceaccount/namespace ]; then
     echo "install APISnoop into this cluster"
     kubectl get ns apisnoop || kubectl create ns apisnoop
-    helm upgrade --install snoopdb -n apisnoop "$SCRIPT_PATH"/../charts/snoopdb
+    helm upgrade --install $EXTRA_ENV snoopdb -n apisnoop "$SCRIPT_PATH"/../charts/snoopdb
     helm upgrade --install auditlogger -n apisnoop "$SCRIPT_PATH"/../charts/auditlogger
 fi
 go get github.com/vmware-tanzu/sonobuoy@latest

--- a/.sharing.io/init
+++ b/.sharing.io/init
@@ -9,6 +9,7 @@ if [[ -z "${TESTING_ONLY}" ]]; then
 else
   echo "TESTING!!!"
   EXTRA_ENV="--set extraEnv[0].name=TESTING_ONLY --set extraEnv[0].value=on"
+fi
 
 if [ -f /var/run/secrets/kubernetes.io/serviceaccount/namespace ]; then
     echo "install APISnoop into this cluster"

--- a/apps/snoopdb/postgres/initdb/301_fn_load_audit_events.sql
+++ b/apps/snoopdb/postgres/initdb/301_fn_load_audit_events.sql
@@ -7,10 +7,14 @@ create or replace function load_audit_events(
   from urllib.request import urlopen
   import json
   import yaml
+  import os
   from snoopUtils import determine_bucket_job, download_and_process_auditlogs
 
   GCS_LOGS="https://storage.googleapis.com/kubernetes-jenkins/logs/"
   RELEASES_URL = "https://raw.githubusercontent.com/cncf/apisnoop/master/resources/coverage/releases.yaml"
+
+  if "TESTING_ONLY" in os.environ:
+    return "TESTING_ONLY is set, no audit events loaded."
 
   releases = yaml.safe_load(urlopen(RELEASES_URL))
   latest_release = releases[0]['version']


### PR DESCRIPTION
This passes in a TESTING_ONLY env if it is found in the instance creation.
With this set, no audit events are loaded in snoopdb's startup. This is
so someone can start up snoopdb and load events manually, to debug this
process, or so someone can use a slim test-writing only version of
snoopdb, since test writers don't necessarily need the full coverage
details.

The aim was to make this env var the lightest intrusion into how things
currently run on snoopdb. Helm charts can initialize env vars in the
snoopdb container, env vars that are then accessible in plpython. This
means we can keep everything as is, but if the env var is present, have
the loading events function return early instead of going through the
full process.