### PR TITLE
No selenium

### DIFF
--- a/apps/snoopdb/postgres/Dockerfile
+++ b/apps/snoopdb/postgres/Dockerfile
@@ -27,11 +27,6 @@ RUN apt-get update \
 RUN python3 --version
 RUN pip3 install --upgrade pip
 RUN pip3 install --upgrade requests
-RUN pip3 install selenium webdriver-manager
-RUN wget "https://github.com/mozilla/geckodriver/releases/download/v0.29.1/geckodriver-v0.29.1-linux64.tar.gz" \
-    && tar xvf geckodriver* \
-    && chmod +x geckodriver \
-    && mv geckodriver /usr/local/bin
 
 RUN env PG_CONFIG=$(which pg_config) \
     && git clone https://github.com/theory/pg-semver.git \

--- a/apps/snoopdb/postgres/snoopUtils.py
+++ b/apps/snoopdb/postgres/snoopUtils.py
@@ -87,7 +87,7 @@ def get_latest_akc_success(url):
     """
     html = urlopen(url).read()
     soup = BeautifulSoup(html,"html.parser")
-    scripts = soup.findAll(is_spyglass_script)
+    scripts = soup.find(is_spyglass_script)
     builds = json.loads(scripts.contents[0].split('allBuilds = ')[1][:-2])
     latest_success = [b for b in builds if b['Result'] == 'SUCCESS'][0]
     return latest_success['ID']

--- a/apps/snoopdb/postgres/snoopUtils.py
+++ b/apps/snoopdb/postgres/snoopUtils.py
@@ -83,7 +83,7 @@ def get_latest_akc_success(url):
     determines latest successful run for ci-audit-kind-conformance and returns its ID as a string.
     """
     html = urlopen(url).read()
-    soup = BeautifulSoup(source,"html.parser")
+    soup = BeautifulSoup(html,"html.parser")
     scripts = soup.findAll(is_spyglass_script)
     builds = json.loads(scripts.contents[0].split('allBuilds = ')[1][:-2])
     latest_success = [b for b in builds if b['Result'] == 'SUCCESS'][0]

--- a/apps/snoopdb/postgres/snoopUtils.py
+++ b/apps/snoopdb/postgres/snoopUtils.py
@@ -8,9 +8,6 @@ from copy import deepcopy
 from functools import reduce
 from collections import defaultdict
 from urllib.parse import urlparse
-import selenium
-from selenium import webdriver
-from webdriver_manager.firefox import GeckoDriverManager
 from bs4 import BeautifulSoup
 import subprocess
 import warnings
@@ -85,15 +82,12 @@ def get_latest_akc_success(url):
     """
     determines latest successful run for ci-audit-kind-conformance and returns its ID as a string.
     """
-    opts = webdriver.FirefoxOptions()
-    opts.headless = True
-    driver = webdriver.Firefox(executable_path=GeckoDriverManager().install(), options=opts)
-    driver.get(url)
-    source = driver.page_source
-    driver.close()
+    html = urlopen(url).read()
     soup = BeautifulSoup(source,"html.parser")
-    latest_success = soup.find('tr', class_="run-success").find('a').get_text()
-    return latest_success
+    scripts = soup.findAll(is_spyglass_script)
+    builds = json.loads(scripts.contents[0].split('allBuilds = ')[1][:-2])
+    latest_success = [b for b in builds if b['Result'] == 'SUCCESS'][0]
+    return latest_success['ID']
 
 def determine_bucket_job(custom_bucket=None, custom_job=None):
     """return tuple of bucket, job, using latest succesfful job of default bucket if no custom bucket or job is given"""

--- a/apps/snoopdb/postgres/snoopUtils.py
+++ b/apps/snoopdb/postgres/snoopUtils.py
@@ -78,6 +78,9 @@ def get_html(url):
     soup = BeautifulSoup(html, 'html.parser')
     return soup
 
+def is_spyglass_script(tag):
+    return tag.name == 'script' and not tag.has_attr('src') and ('allBuilds' in tag.contents[0])
+
 def get_latest_akc_success(url):
     """
     determines latest successful run for ci-audit-kind-conformance and returns its ID as a string.


### PR DESCRIPTION
This removes our heavy selenium dependency, which we needed to get the latest successful job for the `ci-audit-kind-conformance` bucket.   This PR introduces a different way to get that information, which eliminates the need for selenium and its driver dependencies.

In short: we get the latest successful job for a bucket by looking at its prow job history webpage and scraping the latest success.  The above-mentioned bucket has a history page different from the rest, in that the jobs are displayed dynamically...meaning we couldn't just scrape the text file of the page.  Instead, we had to start up a virtual browser that pretended to visit the page, have its javascript run, and then pull the latest job.

However, I realized that the script on the page includes, as a variable, all the information we want.  So in this PR, I adjust the scraping to grab this script, split out the josn from the variable, and then parse the latest success from that.  

This isn't the most ideal solution (that would be having this info available in json somewhere, so we don't have to do web scraping at all), but this PR lets us keep our dependencies down and improves the start time of the snoopdb.