### PR TITLE
use artifacts/metadata.json to get job version

### DIFF
--- a/apps/snoopdb/postgres/snoopUtils.py
+++ b/apps/snoopdb/postgres/snoopUtils.py
@@ -333,10 +333,10 @@ def download_and_process_auditlogs(bucket,job):
     if bucket == 'ci-audit-kind-conformance':
         commit_hash = 'master'
     else: 
-        metadata_url = ''.join([GCS_LOGS, bucket, '/', job, '/finished.json'])
-        print('FINISHED.JSON: ', urlopen(metadata_url).read().decode('utf-8'))
+        metadata_url = ''.join([GCS_LOGS, bucket, '/', job, '/artifacts/metadata.json'])
+        print('METADATA.JSON: ', urlopen(metadata_url).read().decode('utf-8'))
         metadata = json.loads(urlopen(metadata_url).read().decode('utf-8'))
-        commit_hash = metadata["version"].split("+")[1]
+        commit_hash = metadata["job-version"].split("+")[1]
 
     # download all logs
     if bucket == 'ci-audit-kind-conformance':


### PR DESCRIPTION
This swaps out the file we use to determine which version of kubernetes
was used in the test run.  Previously we used /finished.json, but there
are more cases coming up where a successful test run has a new type of
finished.json that does not include the kubernetes version.  Both our
older job runs and the newer ones includes /artifacts/metadata.json,
though, and it's 'job-version' key contains the info we need.