### PR TITLE
Meta refactor

### DIFF
--- a/apps/snoopdb/postgres/Dockerfile
+++ b/apps/snoopdb/postgres/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get update \
   python3-ipdb \
   python3-requests \
   python3-yaml \
+  python3-semver \
   libpq-dev \
   wget \
   make \

--- a/apps/snoopdb/postgres/initdb/301_fn_load_audit_events.sql
+++ b/apps/snoopdb/postgres/initdb/301_fn_load_audit_events.sql
@@ -1,5 +1,5 @@
       create or replace function load_audit_events(
-        custom_bucket text,
+        bucket text,
         custom_job text default null)
 
         returns text AS $$
@@ -21,6 +21,7 @@
         auditlog_file = download_and_process_auditlogs(bucket, job)
 
         release_date = int(meta.timestamp)
+
         # if we are grabbing latest release, and it is on cusp of new release,
         # then test runs will show their version as the next release...which is confusing,
         # this period is a code freeze, where tests can still be added, and so the logs we are

--- a/apps/snoopdb/postgres/initdb/301_fn_load_audit_events.sql
+++ b/apps/snoopdb/postgres/initdb/301_fn_load_audit_events.sql
@@ -18,7 +18,7 @@
         meta = get_meta(bucket,custom_job)
         plpy.log("our bucket and job", detail=[bucket,meta.job])
 
-        auditlog_file = download_and_process_auditlogs(bucket, job)
+        auditlog_file = download_and_process_auditlogs(bucket, meta.job)
 
         release_date = int(meta.timestamp)
 

--- a/apps/snoopdb/postgres/initdb/301_fn_load_audit_events.sql
+++ b/apps/snoopdb/postgres/initdb/301_fn_load_audit_events.sql
@@ -61,7 +61,7 @@
                       audit_logfile = auditlog_file,
                       release = release,
                       bucket = bucket,
-                      job = job,
+                      job = meta.job,
                       release_date = release_date
                   )
         try:

--- a/apps/snoopdb/postgres/initdb/301_fn_load_audit_events.sql
+++ b/apps/snoopdb/postgres/initdb/301_fn_load_audit_events.sql
@@ -66,7 +66,7 @@
                   )
         try:
             plpy.execute(sql)
-            return "events for {} loaded, from {}/{}".format(release, bucket, job)
+            return "events for {} loaded, from {}/{}".format(release, bucket, meta.job)
         except plpy.SPIError as plpyError:
             print("something went wrong with plpy: ")
             return plpyError

--- a/apps/snoopdb/postgres/initdb/301_fn_load_audit_events.sql
+++ b/apps/snoopdb/postgres/initdb/301_fn_load_audit_events.sql
@@ -10,7 +10,6 @@
         import semver
         from snoopUtils import download_and_process_auditlogs, get_meta
 
-        GCS_LOGS="https://storage.googleapis.com/kubernetes-jenkins/logs/"
         RELEASES_URL = "https://raw.githubusercontent.com/cncf/apisnoop/master/resources/coverage/releases.yaml"
 
         releases = yaml.safe_load(urlopen(RELEASES_URL))

--- a/apps/snoopdb/postgres/initdb/301_fn_load_audit_events.sql
+++ b/apps/snoopdb/postgres/initdb/301_fn_load_audit_events.sql
@@ -1,5 +1,5 @@
       create or replace function load_audit_events(
-        custom_bucket text default null,
+        custom_bucket text,
         custom_job text default null)
 
         returns text AS $$

--- a/apps/snoopdb/postgres/initdb/301_fn_load_audit_events.sql
+++ b/apps/snoopdb/postgres/initdb/301_fn_load_audit_events.sql
@@ -15,7 +15,7 @@
         releases = yaml.safe_load(urlopen(RELEASES_URL))
         latest_release = releases[0]['version']
 
-        meta = get_meta(bucket,job)
+        meta = get_meta(bucket,custom_job)
         plpy.log("our bucket and job", detail=[bucket,meta.job])
 
         auditlog_file = download_and_process_auditlogs(bucket, job)

--- a/apps/snoopdb/postgres/initdb/502_load_all_audit_events.sql
+++ b/apps/snoopdb/postgres/initdb/502_load_all_audit_events.sql
@@ -1,5 +1,5 @@
 begin;
-select * from load_audit_events() f("build log");
+select * from load_audit_events('ci-kubernetes-e2e-gci-gce') f("build log");
 select * from load_audit_events('ci-kubernetes-gce-conformance-latest') f("build log");
 select * from load_audit_events('ci-audit-kind-conformance') f("build log");
 commit;

--- a/apps/snoopdb/postgres/snoopUtils.py
+++ b/apps/snoopdb/postgres/snoopUtils.py
@@ -15,10 +15,13 @@ from tempfile import mkdtemp
 import time
 import glob
 
+AKC_BUCKET="ci-audit-kind-conformance"
+KGCL_BUCKET="ci-kubernetes-gce-conformance-latest"
+KEGG_BUCKET="ci-kubernetes-e2e-gci-gce"
+
 AUDIT_KIND_CONFORMANCE_RUNS="https://prow.k8s.io/job-history/kubernetes-jenkins/logs/ci-audit-kind-conformance"
+AUDIT_KIND_CONFORMANCE_LOGS="https://storage.googleapis.com/kubernetes-jenkins/logs/ci-audit-kind-conformance"
 GCS_LOGS="https://storage.googleapis.com/kubernetes-jenkins/logs/"
-DEFAULT_BUCKET="ci-kubernetes-gci-gce"
-K8S_GITHUB_RAW= "https://raw.githubusercontent.com/kubernetes/kubernetes/"
 
 IGNORED_PATHS=[
     'metrics',

--- a/apps/snoopdb/postgres/snoopUtils.py
+++ b/apps/snoopdb/postgres/snoopUtils.py
@@ -32,7 +32,6 @@ IGNORED_PATHS=[
     'wardle.k8s.io'
 ]
 
-#TESTED
 def assign_verb_to_method (verb, uri):
     """Assigns audit event verb to apropriate method for generating opID later.
        Accounts for irregular behaviour with head and option verbs."""
@@ -67,11 +66,9 @@ def get_html(url):
     soup = BeautifulSoup(html, 'html.parser')
     return soup
 
-#TESTED
 def is_spyglass_script(tag):
     return tag.name == 'script' and not tag.has_attr('src') and ('allBuilds' in tag.contents[0])
 
-#TESTED
 def get_latest_akc_success(soup):
     """
     determines latest successful run for ci-audit-kind-conformance and returns its ID as a string.
@@ -89,7 +86,6 @@ def get_latest_akc_success(soup):
         raise ValueError("Cannot find success in builds")
     return latest_success['ID']
 
-# TESTING NOT NECESSARY
 def determine_bucket_job(custom_bucket=None, custom_job=None):
     """return tuple of bucket, job, using latest successful job of default bucket if no custom bucket or job is given"""
     #establish bucket we'll draw test results from.
@@ -108,7 +104,6 @@ def determine_bucket_job(custom_bucket=None, custom_job=None):
         job = baseline_job if custom_job is None else custom_job
     return (bucket, job)
 
-# TESTED
 def merge_into(d1, d2):
     for key in d2:
         if key not in d1 or not isinstance(d1[key], dict):
@@ -117,14 +112,12 @@ def merge_into(d1, d2):
             d1[key] = merge_into(d1[key], d2[key])
     return d1
 
-# TESTED
 def deep_merge(*dicts, update=False):
     if update:
         return reduce(merge_into, dicts[1:], dicts[0])
     else:
         return reduce(merge_into, dicts, {})
 
-# NOT TESTING
 def download_url_to_path(url, local_path, dl_dict):
     """
     downloads contents to local path, creating path if needed,
@@ -137,7 +130,6 @@ def download_url_to_path(url, local_path, dl_dict):
         process = subprocess.Popen(['wget', '-q', url, '-O', local_path])
         dl_dict[local_path] = process
 
-# NOT TESTING
 def get_all_auditlog_links(au):
     """
     given an artifacts url, au, return a list of all
@@ -149,7 +141,6 @@ def get_all_auditlog_links(au):
     master_soup = get_html("https://gcsweb.k8s.io" + master_link['href'])
     return master_soup.find_all(href=re.compile("audit.log"))
 
-# NOT TESTING
 def get_all_audit_kind_links(au):
     """
     grab all the audit logs from our ci-audit-kind-conformance bucket,
@@ -159,7 +150,6 @@ def get_all_audit_kind_links(au):
     print(soup.find_all(href=re.compile(".log")))
     return soup.find_all(href=re.compile(".log"))
 
-# TESTED
 def load_openapi_spec(url):
     # Usually, a Python dictionary throws a KeyError if you try to get an item with a key that is not currently in the dictionary.
     # The defaultdict in contrast will simply return an empty dict.
@@ -202,7 +192,6 @@ def load_openapi_spec(url):
                 openapi_spec['cache'] = cache
     return openapi_spec
 
-#TESTED
 def format_uri_parts_for_proxy(uri_parts):
     proxy = uri_parts.index('proxy')
     formatted_parts=uri_parts[0:proxy+1]
@@ -211,14 +200,11 @@ def format_uri_parts_for_proxy(uri_parts):
         formatted_parts.append('/'.join(proxy_tail))
     return formatted_parts
 
-# TODO create proper regex to find namespace status versus namespace resource status
-# TESTED
 def is_namespace_status(uri_parts):
     if len(uri_parts) != 5:
         return False
     return uri_parts[2] == 'namespaces' and uri_parts[-1] == 'status'
 
-# TESTED
 def format_uri_parts_for_namespace_status(uri_parts):
     # in the open api spec, the namespace endpoints
     # are listed differently from other endpoints.
@@ -229,13 +215,11 @@ def format_uri_parts_for_namespace_status(uri_parts):
     uri_second_half =['{name}','status']
     return uri_first_half + uri_second_half
 
-# TESTED
 def is_namespace_finalize(uri_parts):
     if len(uri_parts) != 5:
         return False
     return uri_parts[2] == 'namespaces' and uri_parts[-1] == 'finalize'
 
-# TESTED
 def format_uri_parts_for_namespace_finalize(uri_parts):
     # Using the same logic as status, but I am uncertain
     # all the various finalize endpoints, so this may not

--- a/apps/snoopdb/postgres/snoopUtils.py
+++ b/apps/snoopdb/postgres/snoopUtils.py
@@ -6,7 +6,7 @@ import requests
 import re
 from copy import deepcopy
 from functools import reduce
-from collections import defaultdict
+from collections import defaultdict, namedtuple
 from urllib.parse import urlparse
 from bs4 import BeautifulSoup
 import subprocess
@@ -26,7 +26,7 @@ GCS_LOGS="https://storage.googleapis.com/kubernetes-jenkins/logs/"
 ARTIFACTS_PATH ='https://gcsweb.k8s.io/gcs/kubernetes-jenkins/logs/'
 K8S_GITHUB_REPO = 'https://raw.githubusercontent.com/kubernetes/kubernetes/'
 
-Meta = collections.namedtuple('Meta',['job','version','commit','log_links','timestamp'])
+Meta = namedtuple('Meta',['job','version','commit','log_links','timestamp'])
 
 IGNORED_PATHS=[
     'metrics',

--- a/apps/snoopdb/postgres/snoopUtils.py
+++ b/apps/snoopdb/postgres/snoopUtils.py
@@ -26,6 +26,8 @@ GCS_LOGS="https://storage.googleapis.com/kubernetes-jenkins/logs/"
 ARTIFACTS_PATH ='https://gcsweb.k8s.io/gcs/kubernetes-jenkins/logs/'
 K8S_GITHUB_REPO = 'https://raw.githubusercontent.com/kubernetes/kubernetes/'
 
+Meta = collections.namedtuple('Meta',['job','version','commit','log_links','timestamp'])
+
 IGNORED_PATHS=[
     'metrics',
     'readyz',


### PR DESCRIPTION
This is an attempt to improve how we grab the metadata for our test runs, knowing that it is possible and likely for the file structure of these test runs to change.

I have created three sets of functions, one for each our buckets, that pull in all the necessary metadata for a run: the bucket and job, the time of the run, the semver of k8s used in the test and the commit of the k8s/k8s repo used, and the list of audit log links for that given bucket and job.

This change required a bit of a refactor across our files, but the aim is to have more consistent errors, and for the functions in general to be shorter and to the point.