### PR TITLE
Update audit and kubeadm policies in kind startup

### DIFF
--- a/kind/audit/policy.yaml
+++ b/kind/audit/policy.yaml
@@ -1,6 +1,6 @@
 # audit-policy.yaml
 
-apiVersion: audit.k8s.io/v1beta1
+apiVersion: audit.k8s.io/v1
 kind: Policy
 rules:
   - level: Metadata

--- a/kind/kind+apisnoop.yaml
+++ b/kind/kind+apisnoop.yaml
@@ -14,7 +14,7 @@ apiVersion: kind.x-k8s.io/v1alpha4
 # so the apiserver can log/auditsink to itself
 kubeadmConfigPatches:
   - |
-    apiVersion: kubeadm.k8s.io/v1beta2
+    apiVersion: kubeadm.k8s.io/v1beta3
     kind: ClusterConfiguration
     metadata:
       name: config


### PR DESCRIPTION
This update makes our config work with latest kind version 0.17.0 and latest kubernetes version v1beta3.  The audit policy version needed to be updated, as beta versions were deprecated.  See: https://github.com/kubernetes/kubernetes/issues/98035

This should fix issue https://github.com/cncf/apisnoop/issues/655, but want to test it with @heyste  first before merging.