### PR TITLE
have updater use snoopdb:latest

### DIFF
--- a/.github/workflows/apisnoop_weekly_updater.yml
+++ b/.github/workflows/apisnoop_weekly_updater.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: start SnoopDB
         run: |
-          docker run -e POSTGRES_USER=apisnoop -e POSTGRES_DB=apisnoop --name snoopdb -d -p 5432:5432 gcr.io/k8s-staging-apisnoop/snoopdb:v20220909-0.2.0-295-g7b8a192 
+          docker run -e POSTGRES_USER=apisnoop -e POSTGRES_DB=apisnoop --name snoopdb -d -p 5432:5432 gcr.io/k8s-staging-apisnoop/snoopdb:latest
           until psql -U apisnoop -d apisnoop -h localhost -c 'select 0;'; do 
             docker logs --tail=100 snoopdb
             sleep 10s


### PR DESCRIPTION
this helps prevent drift when we make changes to the db that should effect our updates