### PR TITLE
remove push dispatch for update action

### DIFF
--- a/.github/workflows/apisnoop_weekly_updater.yml
+++ b/.github/workflows/apisnoop_weekly_updater.yml
@@ -4,9 +4,7 @@ on:
   workflow_dispatch: {}
   schedule:
     - cron: "0 12 * * 6"
-  push:
-    paths:
-      - resources/coverage/*.*.0.json
+
 
 jobs:
   update:


### PR DESCRIPTION
This action is set to dispatch on multiple events. One is a schedule, to run every Saturday, and one is on every push to a coverage json file. This second one causes a loop, since the result of this action will most often be a change to a coverage json.

I propose we eliminate this push event listener, and only have it run on its schedule.

Signed-off-by: Zach Mandeville <zz@ii.coop>