### PR TITLE
tracking CSIDriver coverage

### DIFF
--- a/org/csidriver-coverage.org
+++ b/org/csidriver-coverage.org
@@ -1,0 +1,67 @@
+#+title: CSIDriver Coverage
+#+PROPERTY: header-args:sql-mode :exports both
+
+This is a quick document to see how many of the currently ineligible endpionts
+related to CSIDriver are covered by conformance tests.
+
+
+* What are the current ineligible csiDriver endpoints?
+#+NAME: Ineligible CSIDriver endpoints
+#+begin_src sql-mode
+select endpoint
+  from conformance.ineligible_endpoint
+ where endpoint ilike '%csi%driver%';
+#+end_src
+
+#+RESULTS: CSIDriver coverage
+#+begin_SRC example
+              endpoint
+------------------------------------
+ createStorageV1CSIDriver
+ deleteStorageV1CollectionCSIDriver
+ deleteStorageV1CSIDriver
+ listStorageV1CSIDriver
+ patchStorageV1CSIDriver
+ readStorageV1CSIDriver
+ replaceStorageV1CSIDriver
+(7 rows)
+
+#+end_SRC
+* What's their coverage?
+
+
+#+begin_src sql-mode
+with ineligible_csi as (
+  select endpoint
+    from conformance.ineligible_endpoint
+   where endpoint ilike '%csi%driver%'
+)
+select ae.endpoint, test
+  from audit_event ae
+       join ineligible_csi using(endpoint)
+       join conformance.test test on (test.codename = ae.test)
+ group by ae.endpoint, ae.test
+ order by ae.endpoint, test;
+#+end_src
+
+#+RESULTS:
+#+begin_SRC example
+         endpoint         |                                                    test
+--------------------------+------------------------------------------------------------------------------------------------------------
+ createStorageV1CSIDriver | [sig-storage] CSIInlineVolumes should support ephemeral VolumeLifecycleMode in CSIDriver API [Conformance]
+ deleteStorageV1CSIDriver | [sig-storage] CSIInlineVolumes should support ephemeral VolumeLifecycleMode in CSIDriver API [Conformance]
+ listStorageV1CSIDriver   | [sig-storage] CSIInlineVolumes should support ephemeral VolumeLifecycleMode in CSIDriver API [Conformance]
+ readStorageV1CSIDriver   | [sig-storage] CSIInlineVolumes should support ephemeral VolumeLifecycleMode in CSIDriver API [Conformance]
+(4 rows)
+#+end_SRC
+
+* Conclusion
+
+It looks 4 of the 7 are already covered, the basic crud endpoints.  In total:
+- createStorageV1CSIDriver *TESTED*
+- deleteStorageV1CSIDriver *TESTED*
+- listStorageV1CSIDriver   *TESTED*
+- readStorageV1CSIDriver   *TESTED*
+- deleteStorageV1CollectionCSIDriver
+- patchStorageV1CSIDriver
+- replaceStorageV1CSIDriver


### PR DESCRIPTION
This is a short PR with an org file that compiles to the document below

----

<a id="org9c7d6e4"></a>

# What are the current ineligible csiDriver endpoints?

```sql-mode
select endpoint
  from conformance.ineligible_endpoint
 where endpoint ilike '%csi%driver%';
```

```example
              endpoint              
------------------------------------
 createStorageV1CSIDriver
 deleteStorageV1CollectionCSIDriver
 deleteStorageV1CSIDriver
 listStorageV1CSIDriver
 patchStorageV1CSIDriver
 readStorageV1CSIDriver
 replaceStorageV1CSIDriver
(7 rows)

```

<a id="orgb69ee0f"></a>

# What&rsquo;s their coverage?

```sql-mode
with ineligible_csi as (
  select endpoint
    from conformance.ineligible_endpoint
   where endpoint ilike '%csi%driver%'
)
select ae.endpoint, test
  from audit_event ae
       join ineligible_csi using(endpoint)
       join conformance.test test on (test.codename = ae.test)
 group by ae.endpoint, ae.test
 order by ae.endpoint, test;
```

```example
         endpoint         |                                                    test                                                    
--------------------------+------------------------------------------------------------------------------------------------------------
 createStorageV1CSIDriver | [sig-storage] CSIInlineVolumes should support ephemeral VolumeLifecycleMode in CSIDriver API [Conformance]
 deleteStorageV1CSIDriver | [sig-storage] CSIInlineVolumes should support ephemeral VolumeLifecycleMode in CSIDriver API [Conformance]
 listStorageV1CSIDriver   | [sig-storage] CSIInlineVolumes should support ephemeral VolumeLifecycleMode in CSIDriver API [Conformance]
 readStorageV1CSIDriver   | [sig-storage] CSIInlineVolumes should support ephemeral VolumeLifecycleMode in CSIDriver API [Conformance]
(4 rows)

```


<a id="org84cf3ce"></a>

# Conclusion

It looks 4 of the 7 are already covered, the basic crud endpoints. In total:

-   createStorageV1CSIDriver **TESTED**
-   deleteStorageV1CSIDriver **TESTED**
-   listStorageV1CSIDriver **TESTED**
-   readStorageV1CSIDriver **TESTED**
-   deleteStorageV1CollectionCSIDriver
-   patchStorageV1CSIDriver
-   replaceStorageV1CSIDriver
