### PR TITLE
update apisnoop_weekly_updater.yml by removing apt-get upgrade

### DIFF
--- a/.github/workflows/apisnoop_weekly_updater.yml
+++ b/.github/workflows/apisnoop_weekly_updater.yml
@@ -18,7 +18,6 @@ jobs:
       - name: configure system
         run: |
           sudo apt-get update -y
-          sudo apt-get upgrade -y
           sudo apt-get install -y postgresql-client netcat
           git config user.name 'github-actions[bot]'
           git config user.email 'github-actions[bot]@users.noreply.github.com'


### PR DESCRIPTION
GHA keep failing on `apt-get upgrade` which seem overkill for running a shortlived action.

Tested the new stats by rnning the GHA on this brach. The job completed and created a [PR](https://github.com/cncf/apisnoop/pull/701)