### PR TITLE
add safety check for missing data

### DIFF
--- a/apps/web/src/lib/utils.js
+++ b/apps/web/src/lib/utils.js
@@ -1,0 +1,16 @@
+ import {
+   RELEASES_URL,
+ } from './constants.js';
+
+export async function releaseJsonExists (releases) {
+   const asyncFilter = async (arr, predicate) => {
+     const results = await Promise.all(arr.map(predicate));
+     return arr.filter((_v, index) => results[index]);
+   }
+
+   const releasesWithJson = await asyncFilter(releases, async ({version}) => {
+     let res = await fetch(`${RELEASES_URL}/${version}.json`);
+     return res.ok;
+   });
+   return releasesWithJson;
+ };

--- a/apps/web/src/pages/About.svelte
+++ b/apps/web/src/pages/About.svelte
@@ -5,6 +5,7 @@
  import dayjs from 'dayjs';
  import yaml from 'js-yaml';
  import { gte } from '../lib/semver.js'
+ import { releaseJsonExists } from '../lib/utils.js'
  import {
    activeFilters,
    activeRelease,
@@ -24,25 +25,27 @@
 
  afterUpdate(async() => {
      if ($releases && isEmpty($releases)) {
-         let releasesData = await
-         fetch(`${RELEASES_URL}/releases.yaml`)
-             .then(res => res.blob())
-             .then(blob => blob.text())
-             .then(yamlString => yaml.load(yamlString))
-             .then(releases => releases.filter(({version}) => gte(version, EARLIEST_VERSION)))
-             .then(releases => {
-                 return mapValues(groupBy(releases, 'version'),
-                                  ([{version, release_date}]) => ({
-                                      release: version,
-                                      release_date: release_date == '' ? new Date() : release_date,
-                                      spec: '',
-                                      source: '',
-                                      endpoints: [],
-                                      tests: []
-                 }))
-             });
+       let releasesFromYaml = await fetch(`${RELEASES_URL}/releases.yaml`)
+         .then(res => res.blob())
+         .then(blob => blob.text())
+         .then(yamlString => yaml.load(yamlString))
+         .then(releases => releases.filter(({version}) => gte(version, EARLIEST_VERSION)))
+
+       let releasesData = await releaseJsonExists(releasesFromYaml)
+         .then(releases => {
+           return mapValues(groupBy(releases, 'version'),
+                            ([{version, release_date}]) => ({
+                              release: version,
+                              release_date: release_date == '' ? new Date() : release_date,
+                              spec: '',
+                              source: '',
+                              endpoints: [],
+                              tests: []
+           }))
+         });
          releases.update(rel => releasesData);
      }
+
      if (version === 'latest' || version == null) {
          version = $latestVersion;
      };


### PR DESCRIPTION
this filters the releases, as gathered in our releases.yaml file, to only those that have a coverage json available in our github repo.  This is to prevent a case where the release.yaml has updated, but the coverage json has not been published yet.