### PR TITLE
Crane instead of Gcrane

### DIFF
--- a/.github/workflows/update-image.yaml
+++ b/.github/workflows/update-image.yaml
@@ -27,7 +27,7 @@ jobs:
         run: |
            go version
            go install github.com/google/go-containerregistry/cmd/gcrane@latest
-           gcrane version
+           crane version
 
 
       - name: set sha to var
@@ -43,4 +43,4 @@ jobs:
           max_attempts: 5
           retry_on: error
           timeout_seconds: 30
-          command: gcrane ls gcr.io/k8s-staging-apisnoop/snoopdb  | grep $GITHUB_SHA_SHORT
+          command: crane ls gcr.io/k8s-staging-apisnoop/snoopdb  | grep $GITHUB_SHA_SHORT

--- a/.github/workflows/update-image.yaml
+++ b/.github/workflows/update-image.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: install gcrane
         run: |
            go version
-           go install github.com/google/go-containerregistry/cmd/gcrane@latest
+           go install github.com/google/go-containerregistry/cmd/crane@latest
            crane version
 
 


### PR DESCRIPTION
gcrane seems to need auth, whereas crane does not.

See https://github.com/cncf/apisnoop/actions/runs/4975018916/jobs/8901808815#step:8:1