### PR TITLE
Update knex version in package.json

### DIFF
--- a/apps/auditlogger/package.json
+++ b/apps/auditlogger/package.json
@@ -10,7 +10,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "express": "^4.17.1",
-    "knex": "^0.20.1",
+    "knex": "^2.4.2",
     "morgan": "^1.9.1",
     "pg": "^7.12.1"
   }


### PR DESCRIPTION
Knex Knex.js through 2.3.0 has a limited SQL injection vulnerability that can be exploited to ignore the WHERE clause of a SQL query. This vulnerability has been fixed in version 2.4.0.

[Knex.js has a limited SQL injection vulnerability #11](https://github.com/cncf/apisnoop/security/dependabot/11)