### PR TITLE
only load data if env var LOAD_K8S_DATA is set

### DIFF
--- a/apps/snoopdb/postgres/initdb/500_load_all_open_api.sql
+++ b/apps/snoopdb/postgres/initdb/500_load_all_open_api.sql
@@ -1,3 +1,9 @@
+\set load_k8s_data null
+\getenv load_k8s_data LOAD_K8S_DATA
+select :load_k8s_data is not null as proceed;
+\gset
+
+\if :proceed
 begin;
 select f.*
     from
@@ -5,3 +11,6 @@ select f.*
     , lateral load_open_api(r.release::text) f("build log");
 select * from load_open_api() f("build log");
 commit;
+\else
+ select 'skipping as envvar LOAD_K8S_DATA is not set' as "build log";
+\endif

--- a/apps/snoopdb/postgres/initdb/501_load_all_tests.sql
+++ b/apps/snoopdb/postgres/initdb/501_load_all_tests.sql
@@ -1,3 +1,12 @@
+\set load_k8s_data null
+\getenv load_k8s_data LOAD_K8S_DATA
+select :load_k8s_data is not null as proceed;
+\gset
+
+\if :proceed
 begin;
 select * from load_tests() f("build log");
 commit;
+\else
+ select 'skipping as envvar LOAD_K8S_DATA is not set' as "build log";
+\endif

--- a/apps/snoopdb/postgres/initdb/502_load_all_audit_events.sql
+++ b/apps/snoopdb/postgres/initdb/502_load_all_audit_events.sql
@@ -1,6 +1,15 @@
+\set load_k8s_data null
+\getenv load_k8s_data LOAD_K8S_DATA
+select :load_k8s_data is not null as proceed;
+\gset
+
+\if :proceed
 begin;
 select * from load_audit_events('ci-kubernetes-e2e-gci-gce') f("build log");
 select * from load_audit_events('ci-kubernetes-gce-conformance-latest') f("build log");
 select * from load_audit_events('ci-audit-kind-conformance') f("build log");
 call update_pod_binding_events();
 commit;
+\else
+ select 'skipping as envvar LOAD_K8S_DATA is not set' as "build log";
+\endif

--- a/apps/snoopdb/postgres/initdb/503_load_ineligible_endpoints.sql
+++ b/apps/snoopdb/postgres/initdb/503_load_ineligible_endpoints.sql
@@ -1,3 +1,12 @@
+\set load_k8s_data null
+\getenv load_k8s_data LOAD_K8S_DATA
+select :load_k8s_data is not null as proceed;
+\gset
+
+\if :proceed
 begin;
 select * from load_ineligible_endpoints() f("build log");
 commit;
+\else
+ select 'skipping as envvar LOAD_K8S_DATA is not set' as "build log";
+\endif

--- a/apps/snoopdb/postgres/initdb/504_refresh_eligible_endpoint_coverage.sql
+++ b/apps/snoopdb/postgres/initdb/504_refresh_eligible_endpoint_coverage.sql
@@ -1,4 +1,13 @@
+\set load_k8s_data null
+\getenv load_k8s_data LOAD_K8S_DATA
+select :load_k8s_data is not null as proceed;
+\gset
+
+\if :proceed
 begin;
 refresh materialized view conformance.eligible_endpoint_coverage;
 select 'conformance.eligible_endpoint_coverage re-materialized' as "build log";
 commit;
+\else
+ select 'skipping as envvar LOAD_K8S_DATA is not set' as "build log";
+\endif

--- a/apps/snoopdb/postgres/initdb/505_output_untested_endpoints.sql
+++ b/apps/snoopdb/postgres/initdb/505_output_untested_endpoints.sql
@@ -1,6 +1,10 @@
+\set load_k8s_data null
+\getenv load_k8s_data LOAD_K8S_DATA
+select :load_k8s_data is not null as proceed;
+\gset
+
+\if :proceed
 begin;
-
-
 \t
 \a
 \o '/tmp/untested-endpoints.txt'
@@ -24,3 +28,6 @@ select 'untested endpoints for '||release||' written to /tmp/untested-endpoints.
  order by release::semver desc
  limit 1;
 commit;
+\else
+ select 'skipping as envvar LOAD_K8S_DATA is not set' as "build log";
+\endif

--- a/apps/snoopdb/postgres/initdb/506_output_coverage_jsons.sql
+++ b/apps/snoopdb/postgres/initdb/506_output_coverage_jsons.sql
@@ -1,3 +1,9 @@
+\set load_k8s_data null
+\getenv load_k8s_data LOAD_K8S_DATA
+select :load_k8s_data is not null as proceed;
+\gset
+
+\if :proceed
 begin;
     -- move this to its own block if it works
     CREATE FUNCTION array_distinct(anyarray) RETURNS anyarray AS $f$
@@ -68,3 +74,6 @@ $f$ LANGUAGE SQL IMMUTABLE;
 \a
 \t
 commit;
+\else
+ select 'skipping as envvar LOAD_K8S_DATA is not set' as "build log";
+\endif


### PR DESCRIPTION
This adds a check to all our bootstrapping postgres scripts (the 500's in the initdb folder) to only run if the env var `LOAD_K8S_DATA` is set.

This gives an easy way to provide a slim version of snoopdb, useful for work with knative and istio.  It changes our process for other uses of snoop where we _do_ need that initial data, most critically our updating function in the github workflows.  In that case, though, we just need to pass the env var in our docker run command.