### PR TITLE
Get cluster token

### DIFF
--- a/charts/snoopdb/templates/statefulset.yaml
+++ b/charts/snoopdb/templates/statefulset.yaml
@@ -34,6 +34,13 @@ spec:
       serviceAccountName: {{ include "chart.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      initContainers:
+        - name: cptoken
+          image: busybox
+          command: ['sh', '-c', 'cp /var/run/secrets/kubernetes.io/serviceaccount/token /opt/token.txt ; chmod 644 /opt/token.txt']
+          volumeMounts:
+            - name: data
+              mountPath: /opt
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
@@ -104,6 +111,8 @@ spec:
             mountPath: /var/lib/postgresql
           - name: var-run-postgresql
             mountPath: /var/run/postgresql
+          - name: data
+            mountPath: /opt
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -123,4 +132,5 @@ spec:
           emptyDir: {}
         - name: var-run-postgresql
           emptyDir: {}
-
+        - name: data
+          emptyDir: {}


### PR DESCRIPTION
Updated the snoopdb template with an initContainer that will now allow the postgres user to use the cluster token.

```
$ kubectl -n apisnoop exec -it apisnoop-snoopdb-0 -- bash
Defaulted container "snoopdb" out of: snoopdb, cptoken (init)
root@apisnoop-snoopdb-0:/# su postgres 
postgres@apisnoop-snoopdb-0:/$ ls -l /opt/token.txt 
-rw-r--r-- 1 root 70 1012 Oct  2 02:37 /opt/token.txt
postgres@apisnoop-snoopdb-0:/$ cat /opt/token.txt ; echo
eyJhbGciOiJSUzI1NiIsImtpZCI6IjhuN2J5NW8zWVhCTVRKd3Vvc1p4SkJvUUREYkY1bEhyVG1oN3FuamdPUncifQ.eyJhdWQiOlsiaHR0cHM6Ly9rdWJlcm5ldGVzLmRlZmF1bHQuc3ZjLmNsdXN0ZXIubG9jYWwiXSwiZXhwIjoxNzI3NzUwMjQ5LCJpYXQiOjE2OTYyMTQyNDksImlzcyI6Imh0dHBzOi8va3ViZXJuZXRlcy5kZWZhdWx0LnN2Yy5jbHVzdGVyLmxvY2FsIiwia3ViZXJuZXRlcy5pbyI6eyJuYW1lc3BhY2UiOiJhcGlzbm9vcCIsInBvZCI6eyJuYW1lIjoiYXBpc25vb3Atc25vb3BkYi0wIiwidWlkIjoiYmU4ZThjOGMtMzNlMy00YzBjLTg5ZDUtNjY0NzkyNTY2ZDYyIn0sInNlcnZpY2VhY2NvdW50Ijp7Im5hbWUiOiJkZWZhdWx0IiwidWlkIjoiNzhmMWJmMGEtYWJmYi00MTMyLWJmYzctMDhmNDlkMzQ5MTMxIn0sIndhcm5hZnRlciI6MTY5NjIxNzg1Nn0sIm5iZiI6MTY5NjIxNDI0OSwic3ViIjoic3lzdGVtOnNlcnZpY2VhY2NvdW50OmFwaXNub29wOmRlZmF1bHQifQ.vRQ0grag8k77qmDyhA0ZkYHVSI_f1DIvjtcXhbhWCgvrjrcyBpAVvDvxZNo34sEWpl1fO4SCtHQshwNH3p8R0vibEEtfPk4o_Dcebh0aBRYrTLt-jqjAQDr5MlKON0IfYhKNhJI256wTqFUhD5AuEZ5A_6zmTZuMFDWhfJjjWVRqt-fgwqfwfIbt-UOwJK-7QNIePp_xA4cHP8SEZ9dxWlXqg-Z_1a9KOhSNFrUBn3hf0e3iTMijFe8LcpRkzqF0cKgNyZiPKCxjoe5_jo3uD2IpSe8rFLBLCAaK3WK4knaNuPDluo6-07tmYPFT2erwq-lCjnBpwBhqdEF0eZBeYA
```
