### PR TITLE
Update metadata gathering functions

### DIFF
--- a/apps/snoopdb/postgres/initdb/502_load_all_audit_events.sql
+++ b/apps/snoopdb/postgres/initdb/502_load_all_audit_events.sql
@@ -7,7 +7,7 @@ select :load_k8s_data is not null as proceed;
 begin;
    -- just a test
 select * from load_audit_events('ci-kubernetes-e2e-gci-gce') f("build log");
--- select * from load_audit_events('ci-kubernetes-gce-conformance-latest') f("build log");
+select * from load_audit_events('ci-kubernetes-gce-conformance-latest') f("build log");
 select * from load_audit_events('ci-audit-kind-conformance') f("build log");
 call update_pod_binding_events();
 commit;

--- a/apps/snoopdb/postgres/initdb/502_load_all_audit_events.sql
+++ b/apps/snoopdb/postgres/initdb/502_load_all_audit_events.sql
@@ -6,7 +6,7 @@ select :load_k8s_data is not null as proceed;
 \if :proceed
 begin;
    -- just a test
--- select * from load_audit_events('ci-kubernetes-e2e-gci-gce') f("build log");
+select * from load_audit_events('ci-kubernetes-e2e-gci-gce') f("build log");
 -- select * from load_audit_events('ci-kubernetes-gce-conformance-latest') f("build log");
 select * from load_audit_events('ci-audit-kind-conformance') f("build log");
 call update_pod_binding_events();

--- a/apps/snoopdb/postgres/initdb/502_load_all_audit_events.sql
+++ b/apps/snoopdb/postgres/initdb/502_load_all_audit_events.sql
@@ -5,7 +5,6 @@ select :load_k8s_data is not null as proceed;
 
 \if :proceed
 begin;
-   -- just a test
 select * from load_audit_events('ci-kubernetes-e2e-gci-gce') f("build log");
 select * from load_audit_events('ci-kubernetes-gce-conformance-latest') f("build log");
 select * from load_audit_events('ci-audit-kind-conformance') f("build log");

--- a/apps/snoopdb/postgres/initdb/502_load_all_audit_events.sql
+++ b/apps/snoopdb/postgres/initdb/502_load_all_audit_events.sql
@@ -5,8 +5,9 @@ select :load_k8s_data is not null as proceed;
 
 \if :proceed
 begin;
-select * from load_audit_events('ci-kubernetes-e2e-gci-gce') f("build log");
-select * from load_audit_events('ci-kubernetes-gce-conformance-latest') f("build log");
+   -- just a test
+-- select * from load_audit_events('ci-kubernetes-e2e-gci-gce') f("build log");
+-- select * from load_audit_events('ci-kubernetes-gce-conformance-latest') f("build log");
 select * from load_audit_events('ci-audit-kind-conformance') f("build log");
 call update_pod_binding_events();
 commit;

--- a/apps/snoopdb/postgres/snoopUtils.py
+++ b/apps/snoopdb/postgres/snoopUtils.py
@@ -380,7 +380,7 @@ def kgcl_version(job):
     """
     return k8s semver for version of k8s run in given job's test run
     """
-    finished_url = GCS_LOGS + KEGG_BUCKET + '/' + job + '/finished.json'
+    finished_url = GCS_LOGS + KGCL_BUCKET + '/' + job + '/finished.json'
     finished = get_json(finished_url)
     job_version = finished["metadata"]["job-version"]
 
@@ -396,7 +396,7 @@ def kgcl_commit(job):
     return k8s/k8s commit for k8s used in given job's test run
     """
     # we want the end of the string, after the '+'. A commit should only be numbers and letters
-    finished_url = GCS_LOGS + KEGG_BUCKET + '/' + job + '/finished.json'
+    finished_url = GCS_LOGS + KGCL_BUCKET + '/' + job + '/finished.json'
     finished = get_json(finished_url)
     job_version = finished["metadata"]["job-version"]
 

--- a/apps/snoopdb/postgres/snoopUtils.py
+++ b/apps/snoopdb/postgres/snoopUtils.py
@@ -479,7 +479,7 @@ def kegg_timestamp(job):
     finished = get_json(finished_url)
     return finished["timestamp"]
 
-def kegg_meta(custom_job=None):
+def kegg_meta(bucket, custom_job=None):
     """
     Compose a Meta object for job of given KEGG bucket.
     Meta object contains the job, the k8s version, the k8s commit, the audit log links for the test run, and thed timestamp of the testrun
@@ -504,7 +504,7 @@ def get_meta(bucket,job=None):
     if(bucket == AKC_BUCKET):
         return akc_meta(bucket,job)
     elif(bucket == KGCL_BUCKET):
-        return kgcl_meta(job)
+        return kgcl_meta(bucket,job)
     elif(bucket == KEGG_BUCKET):
         return kegg_meta(job)
 

--- a/apps/snoopdb/postgres/snoopUtils.py
+++ b/apps/snoopdb/postgres/snoopUtils.py
@@ -430,8 +430,8 @@ def kgcl_meta(bucket, custom_job=None):
     """
     job = bucket_latest_success(bucket) if custom_job is None else custom_job
     return Meta(job,
-                kgcl_version(job_version),
-                kgcl_commit(job_version),
+                kgcl_version(job),
+                kgcl_commit(job),
                 kgcl_loglinks(job),
                 kgcl_timestamp(job))
 

--- a/apps/snoopdb/postgres/snoopUtils.py
+++ b/apps/snoopdb/postgres/snoopUtils.py
@@ -295,24 +295,6 @@ def find_operation_id(openapi_spec, event):
     openapi_spec['hit_cache'][url.path][method]=op_id
   return op_id, None
 
-def akc_latest_success():
-    """
-    determines latest successful run for ci-audit-kind-conformance and returns its ID as a string.
-    """
-    soup = get_html(AUDIT_KIND_CONFORMANCE_RUNS)
-    scripts = soup.find(is_spyglass_script)
-    if scripts is None :
-        raise ValueError("No spyglass script found in akc page")
-    try:
-        builds = json.loads(scripts.contents[0].split('allBuilds = ')[1][:-2])
-    except Exception as e:
-        raise ValueError("Could not load json from build data. is it valid json?", e)
-    try:
-        latest_success = [b for b in builds if b['Result'] == 'SUCCESS'][0]
-    except Exception as e:
-        raise ValueError("Cannot find success in builds")
-    return latest_success['ID']
-
 def bucket_latest_success(bucket):
     """
     determines latest successful run for ci-audit-kind-conformance and returns its ID as a string.

--- a/apps/snoopdb/postgres/snoopUtils.py
+++ b/apps/snoopdb/postgres/snoopUtils.py
@@ -468,13 +468,6 @@ def kegg_meta(bucket, custom_job=None):
     Compose a Meta object for job of given KEGG bucket.
     Meta object contains the job, the k8s version, the k8s commit, the audit log links for the test run, and thed timestamp of the testrun
     """
-    # testgrid_history = get_json(GCS_LOGS + KEGG_BUCKET + "/jobResultsCache.json")
-    # if custom_job is not None:
-    #     build = [x for x in testgrid_history if x['buildnumber'] == custom_job][0]
-    # else:
-    #     build = [x for x in testgrid_history if x['result'] == 'SUCCESS'][-1]
-    # job = build["buildnumber"]
-    # job_version = build["job-version"]
     job = bucket_latest_success(bucket) if custom_job is None else custom_job
     return Meta(job,
                 kegg_version(job),

--- a/apps/snoopdb/postgres/snoopUtils.py
+++ b/apps/snoopdb/postgres/snoopUtils.py
@@ -455,7 +455,7 @@ def kegg_commit(job):
     # we want the end of the string, after the '+'. A commit should only be numbers and letters
     finished_url = GCS_LOGS + KEGG_BUCKET + '/' + job + '/finished.json'
     finished = get_json(finished_url)
-    job_version = finished["job_version"]
+    job_version = finished["metadata"]["job-version"]
     match = re.match(".+\+([0-9a-zA-Z]+)$",job_version)
     if match is None:
         raise ValueError("Could not find commit in given job_version.", job_version)

--- a/apps/snoopdb/postgres/snoopUtils.py
+++ b/apps/snoopdb/postgres/snoopUtils.py
@@ -506,7 +506,7 @@ def get_meta(bucket,job=None):
     elif(bucket == KGCL_BUCKET):
         return kgcl_meta(bucket,job)
     elif(bucket == KEGG_BUCKET):
-        return kegg_meta(job)
+        return kegg_meta(bucket, job)
 
 def download_and_process_auditlogs(bucket,job):
     """

--- a/apps/snoopdb/postgres/snoopUtils.py
+++ b/apps/snoopdb/postgres/snoopUtils.py
@@ -20,8 +20,8 @@ from pathlib import Path
 AKC_BUCKET="ci-audit-kind-conformance"
 KGCL_BUCKET="ci-kubernetes-gce-conformance-latest"
 KEGG_BUCKET="ci-kubernetes-e2e-gci-gce"
+CONFORMANCE_RUNS="https://prow.k8s.io/job-history/kubernetes-jenkins/logs/"
 
-AUDIT_KIND_CONFORMANCE_RUNS="https://prow.k8s.io/job-history/kubernetes-jenkins/logs/ci-audit-kind-conformance"
 AUDIT_KIND_CONFORMANCE_LOGS="https://storage.googleapis.com/kubernetes-jenkins/logs/ci-audit-kind-conformance"
 GCS_LOGS="https://storage.googleapis.com/kubernetes-jenkins/logs/"
 
@@ -299,7 +299,7 @@ def bucket_latest_success(bucket):
     """
     determines latest successful run for ci-audit-kind-conformance and returns its ID as a string.
     """
-    test_runs = "https://prow.k8s.io/job-history/kubernetes-jenkins/logs/" + bucket
+    test_runs = CONFORMANCE_RUNS + bucket
     soup = get_html(test_runs)
     scripts = soup.find(is_spyglass_script)
     if scripts is None :

--- a/apps/snoopdb/postgres/snoopUtils.py
+++ b/apps/snoopdb/postgres/snoopUtils.py
@@ -439,7 +439,7 @@ def kegg_version(job):
     """
     finished_url = GCS_LOGS + KEGG_BUCKET + '/' + job + '/finished.json'
     finished = get_json(finished_url)
-    job_version = finished["job_version"]
+    job_version = finished["metadata"]["job-version"]
 
     match = re.match("^v([0-9.]+)-",job_version)
     if match is None:


### PR DESCRIPTION
This PR addresses the issue with our weekly updater receiving a 404 when trying to grab metadata.  Two of the buckets we draw data from were updated and a file we used to rely on is no longer there.  It is possible to get the same data from other means though.

I was hoping that this meant that all three buckets can get their metadata in the same way, and we could condense the functions down to one main set, but unfortunately that is not the case.  One of our buckets is still just slightly different from the rest (namely, that it has a `finished.json` but this file contains less metadata than the other two's `finished.json` so you have to do some spelunking to find out which kubernetes version is being used).   So I kept the style of each bucket having its own set of functions for metadata retrieval because, while unpleasantly verbose, it better illustrates that we cannot expect these three to behave the same.  Any of them could change at any moment, it seems.