### PR TITLE
chore: update snoopdb image version in updater

### DIFF
--- a/.github/workflows/apisnoop_weekly_updater.yml
+++ b/.github/workflows/apisnoop_weekly_updater.yml
@@ -5,6 +5,8 @@ on:
   schedule:
     - cron: "0 12 * * 6"
 
+env:
+  IMAGE: gcr.io/k8s-staging-apisnoop/snoopdb:v20240109-snoopdb-1.4.2-47-g51969fb
 
 jobs:
   update:
@@ -26,7 +28,7 @@ jobs:
 
       - name: start SnoopDB
         run: |
-          docker run -e POSTGRES_USER=apisnoop -e POSTGRES_DB=apisnoop -e LOAD_K8S_DATA=true --name snoopdb -d -p 5432:5432 gcr.io/k8s-staging-apisnoop/snoopdb:v20230912-snoopdb-1.3.0-18-g6d8162d
+          docker run -e POSTGRES_USER=apisnoop -e POSTGRES_DB=apisnoop -e LOAD_K8S_DATA=true --name snoopdb -d -p 5432:5432 $IMAGE
           until psql -U apisnoop -d apisnoop -h localhost -c 'select 0;'; do 
             docker logs --tail=100 snoopdb
             sleep 10s


### PR DESCRIPTION
use gcr.io/k8s-staging-apisnoop/snoopdb:v20240109-snoopdb-1.4.2-47-g51969fb