### PR TITLE
chore: alphasort OWNERS and SECURITY_CONTACTS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,8 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-  - hh
-  - heyste
-  - cooldracula
-  - zachmandeville
   - BobyMCbobs
+  - cooldracula
+  - heyste
+  - hh
+  - zachmandeville

--- a/SECURITY_CONTACTS
+++ b/SECURITY_CONTACTS
@@ -10,8 +10,8 @@
 # DO NOT REPORT SECURITY VULNERABILITIES DIRECTLY TO THESE NAMES, FOLLOW THE
 # INSTRUCTIONS AT https://kubernetes.io/security/
 
-hh
-heyste
-cooldracula
-zachmandeville
 BobyMCbobs
+cooldracula
+heyste
+hh
+zachmandeville


### PR DESCRIPTION
Alpha sort OWNERS and SECURITY_CONTACTS to prepare migration to Kubernetes-sigs (ref https://github.com/kubernetes/org/issues/4705)

cc @BobyMCbobs 