### PR TITLE
snoopdb: honor pending_eligible_endpoints.yaml in the conformance gate

### DIFF
--- a/apps/snoopdb/postgres/initdb/105_table_pending_eligible_endpoint.sql
+++ b/apps/snoopdb/postgres/initdb/105_table_pending_eligible_endpoint.sql
@@ -1,0 +1,7 @@
+create table conformance.pending_eligible_endpoint(
+      endpoint text not null,
+      primary key (endpoint)
+);
+
+comment on table conformance.pending_eligible_endpoint is 'eligible endpoints given a grace period before they fail the conformance gate';
+comment on column conformance.pending_eligible_endpoint.endpoint is 'the pending eligible endpoint';

--- a/apps/snoopdb/postgres/initdb/303_fn_load_ineligible_endpoints.sql
+++ b/apps/snoopdb/postgres/initdb/303_fn_load_ineligible_endpoints.sql
@@ -12,6 +12,8 @@
       MAIN_BRANCH = "master"
       INELIGIBLE_ENDPOINTS = "/test/conformance/testdata/ineligible_endpoints.yaml"
       INELIGIBLE_URL = K8S_REPO_URL + MAIN_BRANCH + INELIGIBLE_ENDPOINTS
+      PENDING_ELIGIBLE_ENDPOINTS = "/test/conformance/testdata/pending_eligible_endpoints.yaml"
+      PENDING_ELIGIBLE_URL = K8S_REPO_URL + MAIN_BRANCH + PENDING_ELIGIBLE_ENDPOINTS
 
       ineligible_endpoints = json.dumps(yaml.safe_load(urlopen(INELIGIBLE_URL)))
       sql = Template("""
@@ -24,13 +26,22 @@
                       (endpoint_data->>'link') as link
                       from jsonb_array;
                    """).substitute(ineligible_endpoints = ineligible_endpoints.replace("'","''"))
+
+      # a plain list of operation ids; the file may hold no list at all
+      # (only a "No pending eligible endpoints" comment), which loads as None
+      pending_eligible_endpoints = json.dumps(yaml.safe_load(urlopen(PENDING_ELIGIBLE_URL)) or [])
+      pending_sql = Template("""
+                   insert into conformance.pending_eligible_endpoint(endpoint)
+                      select jsonb_array_elements_text('${pending_eligible_endpoints}'::jsonb);
+                   """).substitute(pending_eligible_endpoints = pending_eligible_endpoints.replace("'","''"))
       try:
           plpy.execute(sql)
-          return 'ineligible endpoints loaded!'
+          plpy.execute(pending_sql)
+          return 'ineligible and pending eligible endpoints loaded!'
       except Exception as e:
           return 'error occured: ', e
      $$ LANGUAGE plpython3u;
 
-     comment on function load_ineligible_endpoints is 'loads ineligible endpoints from k8s/k8s/test/conformance/testdata';
+     comment on function load_ineligible_endpoints is 'loads ineligible and pending eligible endpoints from k8s/k8s/test/conformance/testdata';
 
      select 'load_ineligible_endpoints function defined and commented' as "build log";

--- a/apps/snoopdb/postgres/initdb/505_output_untested_endpoints.sql
+++ b/apps/snoopdb/postgres/initdb/505_output_untested_endpoints.sql
@@ -19,7 +19,8 @@ begin;
   select endpoint
     from conformance.new_endpoint ne
            join latest_release on ne.release::semver = latest_release.release
-where tested is false;
+where tested is false
+  and endpoint not in (select endpoint from conformance.pending_eligible_endpoint);
 \o
 \a
 \t


### PR DESCRIPTION
**What this PR does / why we need it:**

`apisnoop-conformance-gate` has been red on every run since 2026-07-23 (see kubernetes/kubernetes#141065). kubernetes/kubernetes#137050 added the alpha-only `lifecycle.k8s.io` group, whose versionless group-discovery operation `getLifecycleAPIGroup` registers as stable, and added the endpoint to `test/conformance/testdata/pending_eligible_endpoints.yaml` expecting that to exempt it.

But snoopdb only loads `ineligible_endpoints.yaml` — `pending_eligible_endpoints.yaml` is consumed by test-infra's `audit_log_parser.py` and the apisnoop web UI, not by the gate. So the exemption had no effect and the gate fails with:

```
==================
UNTESTED ENDPOINTS
getLifecycleAPIGroup

==================
ERROR: You have 1 untested endpoints
==================
```

This PR makes the gate honor the pending list:

- new table `conformance.pending_eligible_endpoint` (`105_table_pending_eligible_endpoint.sql`)
- `load_ineligible_endpoints()` also fetches `pending_eligible_endpoints.yaml` (a plain string list; a comment-only file safely loads as an empty list) (`303_fn_load_ineligible_endpoints.sql`)
- the untested-endpoints gate output excludes pending endpoints (`505_output_untested_endpoints.sql`)

Scope is deliberately the gate output only: `conformance.eligible_endpoint` / coverage views are unchanged, so the web UI and coverage stats still show pending endpoints (the UI already fetches the pending yaml separately for display).

**Which issue(s) this PR fixes:**

Refs kubernetes/kubernetes#141065, kubernetes/kubernetes#140523

**Follow-up:**

After this merges and a new snoopdb image is published, the image tag in test-infra `config/jobs/kubernetes/sig-arch/conformance-gate.yaml` (currently `v20250906-auditlogger-1.2.13-125-ga6fd3d3`) needs a bump for the job to pick this up.

**Verification:**

- The embedded plpython body compile-checks, and the yaml→jsonb transform was exercised against the live k/k files: current pending file → `'["getLifecycleAPIGroup"]'::jsonb`, comment-only/empty file → `'[]'::jsonb` (zero rows inserted).
- initdb scripts run in filename order, so 105 (table) → 303/503 (load) → 505 (gate output) sequence holds.
