### PR TITLE
snoopdb: derive group discovery level from the versions a group serves

### DIFF
--- a/apps/snoopdb/postgres/initdb/300_fn_load_open_api.sql
+++ b/apps/snoopdb/postgres/initdb/300_fn_load_open_api.sql
@@ -37,6 +37,51 @@ else:
 sql = Template("""
    WITH open AS (
      SELECT '${open_api}'::jsonb as api_data
+     ),
+   ops AS (
+   SELECT
+     (d.value ->> 'operationId'::text) as endpoint,
+     CASE
+       WHEN paths.key ~~ '%alpha%' THEN 'alpha'
+       WHEN paths.key ~~ '%beta%' THEN 'beta'
+       -- these endpoints are beta, but are not marked as such, yet, in the swagger.json
+       WHEN (d.value ->> 'operationId'::text) = any('{"getServiceAccountIssuerOpenIDConfiguration", "getServiceAccountIssuerOpenIDKeyset"}') THEN 'beta'
+       ELSE 'stable'
+     END AS level,
+     split_part((cat_tag.value ->> 0), '_'::text, 1) AS category,
+     paths.key AS path,
+     ((d.value -> 'x-kubernetes-group-version-kind'::text) ->> 'group'::text) AS k8s_group,
+     ((d.value -> 'x-kubernetes-group-version-kind'::text) ->> 'version'::text) AS k8s_version,
+     ((d.value -> 'x-kubernetes-group-version-kind'::text) ->> 'kind'::text) AS k8s_kind,
+     (d.value ->> 'x-kubernetes-action'::text) AS k8s_action,
+     CASE
+       WHEN (lower((d.value ->> 'description'::text)) ~~ '%deprecated%'::text) THEN true
+       ELSE false
+     END AS deprecated,
+                 (d.value ->> 'description'::text) AS description
+     FROM
+         open
+          , jsonb_each((open.api_data -> 'paths'::text)) paths(key, value)
+          , jsonb_each(paths.value) d(key, value)
+          , jsonb_array_elements((d.value -> 'tags'::text)) cat_tag(value)
+     ),
+   -- a group discovery path, /apis/<group>/, has no version in it for the
+   -- level above to read, so it would come out 'stable'.  a group is only
+   -- as stable as the most stable version it actually serves.
+   -- this needs the group's version paths in the same load.  a per
+   -- group-version source, such as the openapi/v3 documents, would find
+   -- none here and quietly fall back to the path-derived level.
+   group_level AS (
+   SELECT split_part(path, '/', 3) AS api_group,
+     CASE
+       WHEN bool_or(level = 'stable') THEN 'stable'
+       WHEN bool_or(level = 'beta') THEN 'beta'
+       ELSE 'alpha'
+     END AS level
+     FROM ops
+    WHERE path LIKE '/apis/%/%/'
+      AND path NOT LIKE '/apis/%/%/%/'
+    GROUP BY 1
      )
        INSERT INTO open_api(
          release,
@@ -56,32 +101,23 @@ sql = Template("""
    SELECT
      '${release}' as release,
      to_timestamp(${release_date}) as release_date,
-     (d.value ->> 'operationId'::text) as endpoint,
-     CASE
-       WHEN paths.key ~~ '%alpha%' THEN 'alpha'
-       WHEN paths.key ~~ '%beta%' THEN 'beta'
-       -- these endpoints are beta, but are not marked as such, yet, in the swagger.json
-       WHEN (d.value ->> 'operationId'::text) = any('{"getServiceAccountIssuerOpenIDConfiguration", "getServiceAccountIssuerOpenIDKeyset"}') THEN 'beta'
-       ELSE 'stable'
-     END AS level,
-     split_part((cat_tag.value ->> 0), '_'::text, 1) AS category,
-     paths.key AS path,
-     ((d.value -> 'x-kubernetes-group-version-kind'::text) ->> 'group'::text) AS k8s_group,
-     ((d.value -> 'x-kubernetes-group-version-kind'::text) ->> 'version'::text) AS k8s_version,
-     ((d.value -> 'x-kubernetes-group-version-kind'::text) ->> 'kind'::text) AS k8s_kind,
-     (d.value ->> 'x-kubernetes-action'::text) AS k8s_action,
-     CASE
-       WHEN (lower((d.value ->> 'description'::text)) ~~ '%deprecated%'::text) THEN true
-       ELSE false
-     END AS deprecated,
-                 (d.value ->> 'description'::text) AS description,
-                 '${open_api_url}' as spec
-     FROM
-         open
-          , jsonb_each((open.api_data -> 'paths'::text)) paths(key, value)
-          , jsonb_each(paths.value) d(key, value)
-          , jsonb_array_elements((d.value -> 'tags'::text)) cat_tag(value)
-    ORDER BY paths.key;
+     ops.endpoint,
+     -- the group level wins, including over the operationId overrides
+     -- above.  those endpoints are not under /apis/, so it does not bite.
+     coalesce(group_level.level, ops.level) as level,
+     ops.category,
+     ops.path,
+     ops.k8s_group,
+     ops.k8s_version,
+     ops.k8s_kind,
+     ops.k8s_action,
+     ops.deprecated,
+     ops.description,
+     '${open_api_url}' as spec
+     FROM ops
+     LEFT JOIN group_level
+            ON ops.path = '/apis/' || group_level.api_group || '/'
+    ORDER BY ops.path;
               """).substitute(release = release,
                               release_date = str(release_date),
                               open_api = json.dumps(open_api).replace("'","''"),


### PR DESCRIPTION
Related: https://github.com/kubernetes/kubernetes/issues/141065

load_open_api works out alpha/beta/stable from the endpoint's path. Group discovery paths carry no version, because they are what you call to find out what the versions are, so /apis/lifecycle.k8s.io/ loads as 'stable' even though v1alpha1 is the only version the group serves.

Upstream has been working around this by hand. ineligible_endpoints.yaml carries getInternalApiserverAPIGroup, getResourceAPIGroup and getStoragemigrationAPIGroup with the reason "The endpoint is part of a group that has no stable endpoints yet, reporting as a stable endpoint in apisnoop", added in kubernetes/kubernetes#124248. This fixes the misreporting those entries were compensating for.

Split the select into an ops CTE and take the level of a versionless group endpoint from the most stable version its group serves. Doing it in the load rather than as a later fixup means any call of load_open_api() gets it, not just a full initdb run. It also picks up the reverse case, where a group graduates and its discovery endpoint should start counting again.

The group is taken from the path because discovery operations carry no x-kubernetes-group-version-kind, so k8s_group is null for them. The version paths are matched with LIKE rather than a regex because the statement is built with string.Template, where a $ anchor is an invalid placeholder, and escaping it would emit $$ inside the $$ quoted function body.  coalesce leaves a group with no version paths on its path-derived level, which keeps it in the gate rather than dropping it out.

In the latest release this changes 2 rows, getLifecycleAPIGroup and getInternalApiserverAPIGroup, and of those only getLifecycleAPIGroup changes the conformance gate, since the other is already in ineligible_endpoints.yaml.